### PR TITLE
getHref allows the developer to wrap cell value with a Mantine anchor

### DIFF
--- a/package/DataTable.props.ts
+++ b/package/DataTable.props.ts
@@ -122,6 +122,11 @@ export type DataTableColumn<T> = {
   render?: (record: T) => ReactNode;
 
   /**
+   * If provided, this is used to render an Anchor around the cell value
+   */
+  getHref?: (record: T) => string;
+
+  /**
    * Column text alignment; defaults to `left`
    */
   textAlignment?: DataTableColumnTextAlignment;

--- a/package/DataTableRowCell.tsx
+++ b/package/DataTableRowCell.tsx
@@ -1,4 +1,4 @@
-import { Box, createStyles, Sx } from '@mantine/core';
+import { Box, createStyles, Sx, Anchor } from '@mantine/core';
 import { CSSProperties, ReactNode } from 'react';
 import { DataTableColumn } from './DataTable.props';
 import { getValueAtPath, useMediaQueryStringOrFunction } from './utils';
@@ -16,7 +16,7 @@ type DataTableRowCellProps<T> = {
   sx?: Sx;
   style?: CSSProperties;
   record: T;
-} & Pick<DataTableColumn<T>, 'accessor' | 'visibleMediaQuery' | 'textAlignment' | 'width' | 'ellipsis' | 'render'>;
+} & Pick<DataTableColumn<T>, 'accessor' | 'visibleMediaQuery' | 'textAlignment' | 'width' | 'ellipsis' | 'render' | 'getHref'>;
 
 export default function DataTableRowCell<T>({
   className,
@@ -29,9 +29,15 @@ export default function DataTableRowCell<T>({
   width,
   accessor,
   render,
+  getHref
 }: DataTableRowCellProps<T>) {
   const { cx, classes } = useStyles();
   if (!useMediaQueryStringOrFunction(visibleMediaQuery)) return null;
+
+  let cellValue = render ? render(record) : (getValueAtPath(record, accessor) as ReactNode)
+
+  cellValue = getHref ? <Anchor href={getHref(record)}></Anchor> : cellValue
+  
   return (
     <Box
       component="td"
@@ -47,7 +53,7 @@ export default function DataTableRowCell<T>({
       ]}
       style={style}
     >
-      {render ? render(record) : (getValueAtPath(record, accessor) as ReactNode)}
+      {cellValue}
     </Box>
   );
 }


### PR DESCRIPTION
Hi. I have create this PR to allow the developers to wrap a cell value with an anchor. This is often useful if the user needs to click a cell value to open a detailed view. 

Although render can be used to achieve the same, but this function only needs a string to be returned.