### PR TITLE
Implement #28

### DIFF
--- a/package/DataTable.props.ts
+++ b/package/DataTable.props.ts
@@ -7,95 +7,103 @@ import type {
   MantineTheme,
   Sx,
   TableProps,
+  CollapseProps
 } from '@mantine/core';
 import type { CSSProperties, ReactNode } from 'react';
+
+export type ExpandedRowCollapseProps = {
+  transitionDuration?: number;
+  transitionTimingFunction?: string;
+  animateOpacity?: boolean;
+}
+//Extract<CollapseProps, 'animateOpacity' | 'transitionDuration' | 'transitionTimingFunction'>;
 
 export type DataTableColumnTextAlignment = 'left' | 'center' | 'right';
 export type DataTableVerticalAlignment = 'top' | 'center' | 'bottom';
 
 export type DataTableOuterBorderProps =
   | {
-      withBorder?: never;
-      borderRadius?: never;
-    }
+    withBorder?: never;
+    borderRadius?: never;
+  }
   | {
-      /**
-       * If true, table will have border
-       */
-      withBorder: boolean;
+    /**
+     * If true, table will have border
+     */
+    withBorder: boolean;
 
-      /**
-       * Table border radius
-       */
-      borderRadius?: MantineNumberSize;
-    };
+    /**
+     * Table border radius
+     */
+    borderRadius?: MantineNumberSize;
+  };
 
 export type DataTableEmptyStateProps =
   | {
-      /**
-       * Content to show when no records are available; the provided content
-       * will be overlaid and centered automatically
-       */
-      emptyState?: ReactNode;
+    /**
+     * Content to show when no records are available; the provided content
+     * will be overlaid and centered automatically
+     */
+    emptyState?: ReactNode;
 
-      noRecordsText?: never;
-      noRecordsIcon?: never;
-    }
+    noRecordsText?: never;
+    noRecordsIcon?: never;
+  }
   | {
-      emptyState?: never;
+    emptyState?: never;
 
-      /**
-       * Text to show when no records are available
-       */
-      noRecordsText?: string;
+    /**
+     * Text to show when no records are available
+     */
+    noRecordsText?: string;
 
-      /**
-       * Icon to show when no records are available
-       */
-      noRecordsIcon?: ReactNode;
-    };
+    /**
+     * Icon to show when no records are available
+     */
+    noRecordsIcon?: ReactNode;
+  };
 
 export type DataTablePaginationProps =
   | {
-      page?: never;
-      onPageChange?: never;
-      totalRecords?: never;
-      recordsPerPage?: never;
-      paginationSize?: never;
-      paginationText?: never;
-    }
+    page?: never;
+    onPageChange?: never;
+    totalRecords?: never;
+    recordsPerPage?: never;
+    paginationSize?: never;
+    paginationText?: never;
+  }
   | {
-      /**
-       * Current page number (1-based); if provided, a pagination component is shown
-       */
-      page: number;
+    /**
+     * Current page number (1-based); if provided, a pagination component is shown
+     */
+    page: number;
 
-      /**
-       * Callback fired after change of each page
-       */
-      onPageChange: (page: number) => void;
+    /**
+     * Callback fired after change of each page
+     */
+    onPageChange: (page: number) => void;
 
-      /**
-       * Total number of records in the dataset
-       */
-      totalRecords: number | undefined;
+    /**
+     * Total number of records in the dataset
+     */
+    totalRecords: number | undefined;
 
-      /**
-       * Number of records per page
-       */
-      recordsPerPage: number;
+    /**
+     * Number of records per page
+     */
+    recordsPerPage: number;
 
-      /**
-       * Pagination component size; defaults to `sm`
-       */
-      paginationSize?: MantineSize;
+    /**
+     * Pagination component size; defaults to `sm`
+     */
+    paginationSize?: MantineSize;
 
-      /**
-       * Pagination text; defaults to ```({ from, to, totalRecords }) => `${from}-${to}/${totalRecords}`
-       * ```
-       */
-      paginationText?: (options: { from: number; to: number; totalRecords: number }) => ReactNode;
-    };
+    /**
+     * Pagination text; defaults to ```({ from, to, totalRecords }) => `${from}-${to}/${totalRecords}`
+     * ```
+     */
+    paginationText?: (options: { from: number; to: number; totalRecords: number }) => ReactNode;
+  };
 
 export type DataTableColumn<T> = {
   /**
@@ -174,92 +182,92 @@ export type DataTableSortStatus = {
 
 export type DataTableSortProps =
   | {
-      sortStatus?: never;
-      onSortStatusChange?: never;
-    }
+    sortStatus?: never;
+    onSortStatusChange?: never;
+  }
   | {
-      /**
-       * Current sort status (sort column accessor & direction)
-       */
-      sortStatus: DataTableSortStatus;
+    /**
+     * Current sort status (sort column accessor & direction)
+     */
+    sortStatus: DataTableSortStatus;
 
-      /**
-       * Callback fired after change of sort status
-       */
-      onSortStatusChange?: (sortStatus: DataTableSortStatus) => void;
-    };
+    /**
+     * Callback fired after change of sort status
+     */
+    onSortStatusChange?: (sortStatus: DataTableSortStatus) => void;
+  };
 
 export type DataTableSelectionProps<T> =
   | {
-      selectedRecords?: never;
-      onSelectedRecordsChange?: never;
-    }
+    selectedRecords?: never;
+    onSelectedRecordsChange?: never;
+  }
   | {
-      /**
-       * Currently-selected records
-       */
-      selectedRecords: T[];
+    /**
+     * Currently-selected records
+     */
+    selectedRecords: T[];
 
-      /**
-       * Callback fired after change of selected records
-       */
-      onSelectedRecordsChange?: (selectedRecords: T[]) => void;
-    };
+    /**
+     * Callback fired after change of selected records
+     */
+    onSelectedRecordsChange?: (selectedRecords: T[]) => void;
+  };
 
 export type DataTableContextMenuItemProps =
   | {
+    /**
+     * Unique item key
+     */
+    key: string;
+  } & (
+    | {
       /**
-       * Unique item key
+       * If true, insert an actions divider
        */
-      key: string;
-    } & (
-      | {
-          /**
-           * If true, insert an actions divider
-           */
-          divider: true;
-          icon?: never;
-          title?: never;
-          color?: never;
-          hidden?: never;
-          disabled?: never;
-          onClick?: never;
-        }
-      | {
-          divider?: never;
-          /**
-           * Item icon
-           */
-          icon?: ReactNode;
+      divider: true;
+      icon?: never;
+      title?: never;
+      color?: never;
+      hidden?: never;
+      disabled?: never;
+      onClick?: never;
+    }
+    | {
+      divider?: never;
+      /**
+       * Item icon
+       */
+      icon?: ReactNode;
 
-          /**
-           * Item title; if not present, one will be generated by "humanizing"
-           * the provided item key
-           * (i.e. `viewRecord` -> `View record`)
-           */
-          title?: ReactNode;
+      /**
+       * Item title; if not present, one will be generated by "humanizing"
+       * the provided item key
+       * (i.e. `viewRecord` -> `View record`)
+       */
+      title?: ReactNode;
 
-          /**
-           * Item color
-           */
-          color?: MantineColor;
+      /**
+       * Item color
+       */
+      color?: MantineColor;
 
-          /**
-           * if true, the menu item will not be shown
-           */
-          hidden?: boolean;
+      /**
+       * if true, the menu item will not be shown
+       */
+      hidden?: boolean;
 
-          /**
-           * if true, the menu item will be disabled
-           */
-          disabled?: boolean;
+      /**
+       * if true, the menu item will be disabled
+       */
+      disabled?: boolean;
 
-          /**
-           * Function to call when the menu item is clicked
-           */
-          onClick: () => void;
-        }
-    );
+      /**
+       * Function to call when the menu item is clicked
+       */
+      onClick: () => void;
+    }
+  );
 
 export type DataTableProps<T> = {
   /**
@@ -381,6 +389,42 @@ export type DataTableProps<T> = {
      * A function returning the row menu items for the current record
      */
     items: (record: T) => DataTableContextMenuItemProps[];
+  };
+
+  /**
+   * Defines a custom component to render beneath the related record's row
+   */
+  expandedRow?: {
+    /**
+     * Defines when rows should expand; defaults to `click`
+     * May pass a custom function that receives the current record;
+     * if true, that row will be expanded
+     */
+    expandRowOn?: 'click' | 'always' | ((record: T) => boolean);
+
+    /**
+     * Defined if multiple rows are allowed to be expanded at the same time; defaults to `false`
+     */
+    expandMultiple?: boolean;
+
+    /**
+     * Defines the record that will be expanded when the table is first loaded;
+     * defaults to `undefined`;
+     * does nothing if `expandRowOn === 'always'`
+     */
+    expandFirst?: unknown;
+
+    /**
+     * Pass additional props to the Mantine Collapse component wrapping the custom component;
+     * does not accept the `children`, `in`, or `onTransitionEnd` properties
+     */
+    collapseProps?: ExpandedRowCollapseProps;
+
+    /**
+     * Custom component to be rendered;
+     * accepts the current record
+     */
+    item: (record: T) => ReactNode;
   };
 } & Pick<TableProps, 'striped' | 'highlightOnHover' | 'horizontalSpacing' | 'verticalSpacing' | 'fontSize'> &
   Omit<DefaultProps<'root' | 'header' | 'pagination', CSSProperties>, 'unstyled'> &

--- a/package/DataTable.props.ts
+++ b/package/DataTable.props.ts
@@ -11,12 +11,7 @@ import type {
 } from '@mantine/core';
 import type { CSSProperties, ReactNode } from 'react';
 
-export type ExpandedRowCollapseProps = {
-  transitionDuration?: number;
-  transitionTimingFunction?: string;
-  animateOpacity?: boolean;
-}
-//Extract<CollapseProps, 'animateOpacity' | 'transitionDuration' | 'transitionTimingFunction'>;
+export type ExpandedRowCollapseProps = Pick<CollapseProps, 'animateOpacity' | 'transitionDuration' | 'transitionTimingFunction'>;
 
 export type DataTableColumnTextAlignment = 'left' | 'center' | 'right';
 export type DataTableVerticalAlignment = 'top' | 'center' | 'bottom';

--- a/package/DataTable.props.ts
+++ b/package/DataTable.props.ts
@@ -7,98 +7,101 @@ import type {
   MantineTheme,
   Sx,
   TableProps,
-  CollapseProps
+  CollapseProps,
 } from '@mantine/core';
 import type { CSSProperties, ReactNode } from 'react';
 
-export type ExpandedRowCollapseProps = Pick<CollapseProps, 'animateOpacity' | 'transitionDuration' | 'transitionTimingFunction'>;
+export type ExpandedRowCollapseProps = Pick<
+  CollapseProps,
+  'animateOpacity' | 'transitionDuration' | 'transitionTimingFunction'
+>;
 
 export type DataTableColumnTextAlignment = 'left' | 'center' | 'right';
 export type DataTableVerticalAlignment = 'top' | 'center' | 'bottom';
 
 export type DataTableOuterBorderProps =
   | {
-    withBorder?: never;
-    borderRadius?: never;
-  }
+      withBorder?: never;
+      borderRadius?: never;
+    }
   | {
-    /**
-     * If true, table will have border
-     */
-    withBorder: boolean;
+      /**
+       * If true, table will have border
+       */
+      withBorder: boolean;
 
-    /**
-     * Table border radius
-     */
-    borderRadius?: MantineNumberSize;
-  };
+      /**
+       * Table border radius
+       */
+      borderRadius?: MantineNumberSize;
+    };
 
 export type DataTableEmptyStateProps =
   | {
-    /**
-     * Content to show when no records are available; the provided content
-     * will be overlaid and centered automatically
-     */
-    emptyState?: ReactNode;
+      /**
+       * Content to show when no records are available; the provided content
+       * will be overlaid and centered automatically
+       */
+      emptyState?: ReactNode;
 
-    noRecordsText?: never;
-    noRecordsIcon?: never;
-  }
+      noRecordsText?: never;
+      noRecordsIcon?: never;
+    }
   | {
-    emptyState?: never;
+      emptyState?: never;
 
-    /**
-     * Text to show when no records are available
-     */
-    noRecordsText?: string;
+      /**
+       * Text to show when no records are available
+       */
+      noRecordsText?: string;
 
-    /**
-     * Icon to show when no records are available
-     */
-    noRecordsIcon?: ReactNode;
-  };
+      /**
+       * Icon to show when no records are available
+       */
+      noRecordsIcon?: ReactNode;
+    };
 
 export type DataTablePaginationProps =
   | {
-    page?: never;
-    onPageChange?: never;
-    totalRecords?: never;
-    recordsPerPage?: never;
-    paginationSize?: never;
-    paginationText?: never;
-  }
+      page?: never;
+      onPageChange?: never;
+      totalRecords?: never;
+      recordsPerPage?: never;
+      paginationSize?: never;
+      paginationText?: never;
+    }
   | {
-    /**
-     * Current page number (1-based); if provided, a pagination component is shown
-     */
-    page: number;
+      /**
+       * Current page number (1-based); if provided, a pagination component is shown
+       */
+      page: number;
 
-    /**
-     * Callback fired after change of each page
-     */
-    onPageChange: (page: number) => void;
+      /**
+       * Callback fired after change of each page
+       */
+      onPageChange: (page: number) => void;
 
-    /**
-     * Total number of records in the dataset
-     */
-    totalRecords: number | undefined;
+      /**
+       * Total number of records in the dataset
+       */
+      totalRecords: number | undefined;
 
-    /**
-     * Number of records per page
-     */
-    recordsPerPage: number;
+      /**
+       * Number of records per page
+       */
+      recordsPerPage: number;
 
-    /**
-     * Pagination component size; defaults to `sm`
-     */
-    paginationSize?: MantineSize;
+      /**
+       * Pagination component size; defaults to `sm`
+       */
+      paginationSize?: MantineSize;
 
-    /**
-     * Pagination text; defaults to ```({ from, to, totalRecords }) => `${from}-${to}/${totalRecords}`
-     * ```
-     */
-    paginationText?: (options: { from: number; to: number; totalRecords: number }) => ReactNode;
-  };
+      /**
+       * Pagination text; defaults to ```({ from, to, totalRecords }) => `${from}-${to}/${totalRecords}`
+       * ```
+       */
+      paginationText?: (options: { from: number; to: number; totalRecords: number }) => ReactNode;
+    };
 
 export type DataTableColumn<T> = {
   /**
@@ -177,92 +180,92 @@ export type DataTableSortStatus = {
 
 export type DataTableSortProps =
   | {
-    sortStatus?: never;
-    onSortStatusChange?: never;
-  }
+      sortStatus?: never;
+      onSortStatusChange?: never;
+    }
   | {
-    /**
-     * Current sort status (sort column accessor & direction)
-     */
-    sortStatus: DataTableSortStatus;
+      /**
+       * Current sort status (sort column accessor & direction)
+       */
+      sortStatus: DataTableSortStatus;
 
-    /**
-     * Callback fired after change of sort status
-     */
-    onSortStatusChange?: (sortStatus: DataTableSortStatus) => void;
-  };
+      /**
+       * Callback fired after change of sort status
+       */
+      onSortStatusChange?: (sortStatus: DataTableSortStatus) => void;
+    };
 
 export type DataTableSelectionProps<T> =
   | {
-    selectedRecords?: never;
-    onSelectedRecordsChange?: never;
-  }
+      selectedRecords?: never;
+      onSelectedRecordsChange?: never;
+    }
   | {
-    /**
-     * Currently-selected records
-     */
-    selectedRecords: T[];
+      /**
+       * Currently-selected records
+       */
+      selectedRecords: T[];
 
-    /**
-     * Callback fired after change of selected records
-     */
-    onSelectedRecordsChange?: (selectedRecords: T[]) => void;
-  };
+      /**
+       * Callback fired after change of selected records
+       */
+      onSelectedRecordsChange?: (selectedRecords: T[]) => void;
+    };
 
 export type DataTableContextMenuItemProps =
   | {
-    /**
-     * Unique item key
-     */
-    key: string;
-  } & (
-    | {
       /**
-       * If true, insert an actions divider
+       * Unique item key
        */
-      divider: true;
-      icon?: never;
-      title?: never;
-      color?: never;
-      hidden?: never;
-      disabled?: never;
-      onClick?: never;
-    }
-    | {
-      divider?: never;
-      /**
-       * Item icon
-       */
-      icon?: ReactNode;
+      key: string;
+    } & (
+      | {
+          /**
+           * If true, insert an actions divider
+           */
+          divider: true;
+          icon?: never;
+          title?: never;
+          color?: never;
+          hidden?: never;
+          disabled?: never;
+          onClick?: never;
+        }
+      | {
+          divider?: never;
+          /**
+           * Item icon
+           */
+          icon?: ReactNode;
 
-      /**
-       * Item title; if not present, one will be generated by "humanizing"
-       * the provided item key
-       * (i.e. `viewRecord` -> `View record`)
-       */
-      title?: ReactNode;
+          /**
+           * Item title; if not present, one will be generated by "humanizing"
+           * the provided item key
+           * (i.e. `viewRecord` -> `View record`)
+           */
+          title?: ReactNode;
 
-      /**
-       * Item color
-       */
-      color?: MantineColor;
+          /**
+           * Item color
+           */
+          color?: MantineColor;
 
-      /**
-       * if true, the menu item will not be shown
-       */
-      hidden?: boolean;
+          /**
+           * if true, the menu item will not be shown
+           */
+          hidden?: boolean;
 
-      /**
-       * if true, the menu item will be disabled
-       */
-      disabled?: boolean;
+          /**
+           * if true, the menu item will be disabled
+           */
+          disabled?: boolean;
 
-      /**
-       * Function to call when the menu item is clicked
-       */
-      onClick: () => void;
-    }
-  );
+          /**
+           * Function to call when the menu item is clicked
+           */
+          onClick: () => void;
+        }
+    );
 
 export type DataTableProps<T> = {
   /**

--- a/package/DataTable.tsx
+++ b/package/DataTable.tsx
@@ -1,6 +1,6 @@
 import { Box, createStyles, MantineSize, MantineTheme, packSx, Table } from '@mantine/core';
 import { useDebouncedState, useElementSize } from '@mantine/hooks';
-import { CSSProperties, Key, useEffect, useState, useCallback } from 'react';
+import { CSSProperties, Key, useEffect, useState } from 'react';
 import { DataTableProps } from './DataTable.props';
 import DataTableEmptyRow from './DataTableEmptyRow';
 import DataTableEmptyState from './DataTableEmptyState';
@@ -207,14 +207,13 @@ export default function DataTable<T>({
     onPageChange!(page);
   };
 
-  const {expandRowOn = 'click', expandMultiple = false, expandFirst, collapseProps} = expandedRow ?? {};
+  const { expandRowOn = 'click', expandMultiple = false, expandFirst, collapseProps } = expandedRow ?? {};
 
-  let initialExpandedRows = expandRowOn === "always" ? [] : [expandFirst];
+  const initialExpandedRows = expandRowOn === 'always' ? [] : [expandFirst];
   const [expandedRowIds, setExpandedRowIds] = useState<unknown[]>(initialExpandedRows);
-  const changeExpandedRowIds =
-    expandMultiple
-      ? (recordID: unknown) => setExpandedRowIds([...(expandedRowIds as unknown[]), recordID])
-      : (recordID: unknown) => setExpandedRowIds([recordID]);
+  const changeExpandedRowIds = expandMultiple
+    ? (recordID: unknown) => setExpandedRowIds([...(expandedRowIds as unknown[]), recordID])
+    : (recordID: unknown) => setExpandedRowIds([recordID]);
 
   useEffect(() => {
     if (typeof expandRowOn === 'function' && records) {
@@ -228,7 +227,7 @@ export default function DataTable<T>({
       }
       setExpandedRowIds(rowIds);
     }
-  }, [records, expandRowOn, expandMultiple]);
+  }, [records, idAccessor, expandRowOn, expandMultiple]);
 
   const recordsLength = records?.length;
   const recordIds = records?.map((record) => getValueAtPath(record, idAccessor));
@@ -298,12 +297,12 @@ export default function DataTable<T>({
             onSelectionChange={
               onSelectedRecordsChange
                 ? () => {
-                  onSelectedRecordsChange(
-                    allRecordsSelected
-                      ? selectedRecords.filter((record) => !recordIds.includes(getValueAtPath(record, idAccessor)))
-                      : uniqBy([...selectedRecords, ...records!], (record) => getValueAtPath(record, idAccessor))
-                  );
-                }
+                    onSelectedRecordsChange(
+                      allRecordsSelected
+                        ? selectedRecords.filter((record) => !recordIds.includes(getValueAtPath(record, idAccessor)))
+                        : uniqBy([...selectedRecords, ...records!], (record) => getValueAtPath(record, idAccessor))
+                    );
+                  }
                 : undefined
             }
             leftShadowVisible={selectionVisibleAndNotScrolledToLeft}
@@ -338,59 +337,59 @@ export default function DataTable<T>({
                     onSelectionChange={
                       onSelectedRecordsChange
                         ? (e) => {
-                          if ((e.nativeEvent as PointerEvent).shiftKey && lastSelectionChangeIndex !== null) {
-                            const recordsInterval = records.filter(
-                              recordIndex > lastSelectionChangeIndex
-                                ? (_, index) => index >= lastSelectionChangeIndex && index <= recordIndex
-                                : (_, index) => index >= recordIndex && index <= lastSelectionChangeIndex
-                            );
-                            onSelectedRecordsChange(
-                              selected
-                                ? differenceBy(selectedRecords, recordsInterval, (r) => getValueAtPath(r, idAccessor))
-                                : uniqBy([...selectedRecords, ...recordsInterval], (r) =>
-                                  getValueAtPath(r, idAccessor)
-                                )
-                            );
-                          } else {
-                            onSelectedRecordsChange(
-                              selected
-                                ? selectedRecords.filter((record) => getValueAtPath(record, idAccessor) !== recordId)
-                                : uniqBy([...selectedRecords, record], (record) => getValueAtPath(record, idAccessor))
-                            );
+                            if ((e.nativeEvent as PointerEvent).shiftKey && lastSelectionChangeIndex !== null) {
+                              const recordsInterval = records.filter(
+                                recordIndex > lastSelectionChangeIndex
+                                  ? (_, index) => index >= lastSelectionChangeIndex && index <= recordIndex
+                                  : (_, index) => index >= recordIndex && index <= lastSelectionChangeIndex
+                              );
+                              onSelectedRecordsChange(
+                                selected
+                                  ? differenceBy(selectedRecords, recordsInterval, (r) => getValueAtPath(r, idAccessor))
+                                  : uniqBy([...selectedRecords, ...recordsInterval], (r) =>
+                                      getValueAtPath(r, idAccessor)
+                                    )
+                              );
+                            } else {
+                              onSelectedRecordsChange(
+                                selected
+                                  ? selectedRecords.filter((record) => getValueAtPath(record, idAccessor) !== recordId)
+                                  : uniqBy([...selectedRecords, record], (record) => getValueAtPath(record, idAccessor))
+                              );
+                            }
+                            setLastSelectionChangeIndex(recordIndex);
                           }
-                          setLastSelectionChangeIndex(recordIndex);
-                        }
                         : undefined
                     }
                     onClick={
                       showContextMenuOnClick
                         ? expandRowOn === 'click'
                           ? (e) => {
-                            setRowContextMenuInfo({ top: e.clientY, left: e.clientX, record });
-                            changeExpandedRowIds(recordId);
-                            onRowClick?.(record);
-                          }
-                          : (e) => {
-                            setRowContextMenuInfo({ top: e.clientY, left: e.clientX, record });
-                            onRowClick?.(record);
-                          }
-                        : expandRowOn === 'click'
-                          ? () => {
-                            changeExpandedRowIds(recordId);
-                            onRowClick?.(record);
-                          }
-                          : onRowClick
-                            ? () => {
-                              onRowClick(record);
+                              setRowContextMenuInfo({ top: e.clientY, left: e.clientX, record });
+                              changeExpandedRowIds(recordId);
+                              onRowClick?.(record);
                             }
-                            : undefined
+                          : (e) => {
+                              setRowContextMenuInfo({ top: e.clientY, left: e.clientX, record });
+                              onRowClick?.(record);
+                            }
+                        : expandRowOn === 'click'
+                        ? () => {
+                            changeExpandedRowIds(recordId);
+                            onRowClick?.(record);
+                          }
+                        : onRowClick
+                        ? () => {
+                            onRowClick(record);
+                          }
+                        : undefined
                     }
                     onContextMenu={
                       showContextMenuOnRightClick
                         ? (e) => {
-                          e.preventDefault();
-                          setRowContextMenuInfo({ top: e.clientY, left: e.clientX, record });
-                        }
+                            e.preventDefault();
+                            setRowContextMenuInfo({ top: e.clientY, left: e.clientX, record });
+                          }
                         : undefined
                     }
                     contextMenuVisible={
@@ -398,7 +397,7 @@ export default function DataTable<T>({
                     }
                     leftShadowVisible={selectionVisibleAndNotScrolledToLeft}
                     expandedRow={expandedRow?.item}
-                    isExpanded={expandRowOn === "always" ? true : expandedRowIds.includes(recordId)}
+                    isExpanded={expandRowOn === 'always' ? true : expandedRowIds.includes(recordId)}
                     collapseProps={collapseProps ?? {}}
                   />
                 );

--- a/package/DataTable.tsx
+++ b/package/DataTable.tsx
@@ -212,8 +212,14 @@ export default function DataTable<T>({
   const initialExpandedRows = expandRowOn === 'always' ? [] : [expandFirst];
   const [expandedRowIds, setExpandedRowIds] = useState<unknown[]>(initialExpandedRows);
   const changeExpandedRowIds = expandMultiple
-    ? (recordID: unknown) => setExpandedRowIds([...(expandedRowIds as unknown[]), recordID])
-    : (recordID: unknown) => setExpandedRowIds([recordID]);
+    ? (recordID: unknown, isExpanded: boolean) => {
+        isExpanded
+          ? setExpandedRowIds(expandedRowIds.filter((currentID) => currentID !== recordID))
+          : setExpandedRowIds([...(expandedRowIds as unknown[]), recordID]);
+      }
+    : (recordID: unknown, isExpanded: boolean) => {
+        isExpanded ? setExpandedRowIds([]) : setExpandedRowIds([recordID]);
+      };
 
   useEffect(() => {
     if (typeof expandRowOn === 'function' && records) {
@@ -313,6 +319,7 @@ export default function DataTable<T>({
               records.map((record, recordIndex) => {
                 const recordId = getValueAtPath(record, idAccessor);
                 const selected = selectedRecordIds?.includes(recordId) || false;
+                const isExpanded = expandRowOn === 'always' ? true : expandedRowIds.includes(recordId);
 
                 let showContextMenuOnClick = false;
                 let showContextMenuOnRightClick = false;
@@ -366,7 +373,7 @@ export default function DataTable<T>({
                         ? expandRowOn === 'click'
                           ? (e) => {
                               setRowContextMenuInfo({ top: e.clientY, left: e.clientX, record });
-                              changeExpandedRowIds(recordId);
+                              changeExpandedRowIds(recordId, isExpanded);
                               onRowClick?.(record);
                             }
                           : (e) => {
@@ -375,7 +382,7 @@ export default function DataTable<T>({
                             }
                         : expandRowOn === 'click'
                         ? () => {
-                            changeExpandedRowIds(recordId);
+                            changeExpandedRowIds(recordId, isExpanded);
                             onRowClick?.(record);
                           }
                         : onRowClick
@@ -397,7 +404,7 @@ export default function DataTable<T>({
                     }
                     leftShadowVisible={selectionVisibleAndNotScrolledToLeft}
                     expandedRow={expandedRow?.item}
-                    isExpanded={expandRowOn === 'always' ? true : expandedRowIds.includes(recordId)}
+                    isExpanded={isExpanded}
                     collapseProps={collapseProps ?? {}}
                   />
                 );

--- a/package/DataTableRow.tsx
+++ b/package/DataTableRow.tsx
@@ -1,6 +1,6 @@
-import { Checkbox, createStyles } from '@mantine/core';
+import { Checkbox, createStyles, Collapse } from '@mantine/core';
 import { ChangeEventHandler, MouseEventHandler } from 'react';
-import { DataTableColumn } from './DataTable.props';
+import { DataTableColumn, DataTableProps, ExpandedRowCollapseProps } from './DataTable.props';
 import DataTableRowCell from './DataTableRowCell';
 
 const useStyles = createStyles((theme) => {
@@ -68,7 +68,7 @@ const useStyles = createStyles((theme) => {
   };
 });
 
-type DataTableRowProps<T> = {
+interface DataTableRowProps<T> {
   record: T;
   columns: DataTableColumn<T>[];
   selectionVisible: boolean;
@@ -78,10 +78,15 @@ type DataTableRowProps<T> = {
   onContextMenu: MouseEventHandler<HTMLTableRowElement> | undefined;
   contextMenuVisible: boolean;
   leftShadowVisible: boolean;
-  child?: (record: T) => React.ReactNode;
 };
 
-export default function DataTableRow<T>({
+interface DataTableRowParentProps<T> extends DataTableRowProps<T> {
+  expandedRow: ((record: T) => React.ReactNode) | undefined;
+  isExpanded: boolean;
+  collapseProps: ExpandedRowCollapseProps;
+};
+
+export default function DataTableRowParent<T>({
   record,
   columns,
   selectionVisible,
@@ -91,9 +96,11 @@ export default function DataTableRow<T>({
   onContextMenu,
   contextMenuVisible,
   leftShadowVisible,
-  child,
-}: DataTableRowProps<T>) {
-  const dataTableRow = getDataTableRow({
+  expandedRow,
+  isExpanded,
+  collapseProps
+}: DataTableRowParentProps<T>) {
+  const dataTableRow = DataTableRow({
     record,
     columns,
     selectionVisible,
@@ -105,11 +112,19 @@ export default function DataTableRow<T>({
     leftShadowVisible
   });
 
-  if (child) {
+  if (expandedRow) {
+    const {animateOpacity, transitionDuration, transitionTimingFunction} = collapseProps;
     return (
       <>
         {dataTableRow}
-        {child(record)}
+        <Collapse
+          in={isExpanded}
+          animateOpacity={animateOpacity}
+          transitionDuration={transitionDuration}
+          transitionTimingFunction={transitionTimingFunction}
+        >
+          {expandedRow(record)}
+        </Collapse>
       </>
     );
   }
@@ -118,7 +133,7 @@ export default function DataTableRow<T>({
   }
 }
 
-function getDataTableRow<T>({
+function DataTableRow<T>({
   record,
   columns,
   selectionVisible,

--- a/package/DataTableRow.tsx
+++ b/package/DataTableRow.tsx
@@ -68,7 +68,7 @@ const useStyles = createStyles((theme) => {
   };
 });
 
-interface DataTableRowProps<T> {
+interface DataTableRowBaseProps<T> {
   record: T;
   columns: DataTableColumn<T>[];
   selectionVisible: boolean;
@@ -80,7 +80,11 @@ interface DataTableRowProps<T> {
   leftShadowVisible: boolean;
 }
 
-interface DataTableRowParentProps<T> extends DataTableRowProps<T> {
+interface DataTableRowChildProps<T> extends DataTableRowBaseProps<T> {
+  styles: ReturnType<typeof useStyles>;
+}
+
+interface DataTableRowParentProps<T> extends DataTableRowBaseProps<T> {
   expandedRow: ((record: T) => React.ReactNode) | undefined;
   isExpanded: boolean;
   collapseProps: ExpandedRowCollapseProps;
@@ -100,6 +104,9 @@ export default function DataTableRowParent<T>({
   isExpanded,
   collapseProps,
 }: DataTableRowParentProps<T>) {
+  const styles = useStyles();
+  const { classes } = styles;
+
   const dataTableRow = DataTableRow({
     record,
     columns,
@@ -110,13 +117,17 @@ export default function DataTableRowParent<T>({
     onContextMenu,
     contextMenuVisible,
     leftShadowVisible,
+    styles,
   });
 
   if (expandedRow) {
     const { animateOpacity, transitionDuration, transitionTimingFunction } = collapseProps;
+    const columnCount = selectionVisible ? columns.length + 1 : columns.length;
     return (
       <>
         {dataTableRow}
+        <tr>
+          <td colSpan={columnCount} className={classes.expandedRow}>
         <Collapse
           in={isExpanded}
           animateOpacity={animateOpacity}
@@ -125,6 +136,8 @@ export default function DataTableRowParent<T>({
         >
           {expandedRow(record)}
         </Collapse>
+          </td>
+        </tr>
       </>
     );
   } else {
@@ -142,8 +155,9 @@ function DataTableRow<T>({
   onContextMenu,
   contextMenuVisible,
   leftShadowVisible,
-}: DataTableRowProps<T>) {
-  const { cx, classes } = useStyles();
+  styles,
+}: DataTableRowChildProps<T>) {
+  const { cx, classes } = styles;
 
   return (
     <tr

--- a/package/DataTableRow.tsx
+++ b/package/DataTableRow.tsx
@@ -78,9 +78,47 @@ type DataTableRowProps<T> = {
   onContextMenu: MouseEventHandler<HTMLTableRowElement> | undefined;
   contextMenuVisible: boolean;
   leftShadowVisible: boolean;
+  child?: (record: T) => React.ReactNode;
 };
 
 export default function DataTableRow<T>({
+  record,
+  columns,
+  selectionVisible,
+  selectionChecked,
+  onSelectionChange,
+  onClick,
+  onContextMenu,
+  contextMenuVisible,
+  leftShadowVisible,
+  child,
+}: DataTableRowProps<T>) {
+  const dataTableRow = getDataTableRow({
+    record,
+    columns,
+    selectionVisible,
+    selectionChecked,
+    onSelectionChange,
+    onClick,
+    onContextMenu,
+    contextMenuVisible,
+    leftShadowVisible
+  });
+
+  if (child) {
+    return (
+      <>
+        {dataTableRow}
+        {child(record)}
+      </>
+    );
+  }
+  else {
+    return dataTableRow;
+  }
+}
+
+function getDataTableRow<T>({
   record,
   columns,
   selectionVisible,

--- a/package/DataTableRow.tsx
+++ b/package/DataTableRow.tsx
@@ -1,6 +1,6 @@
 import { Checkbox, createStyles, Collapse } from '@mantine/core';
 import { ChangeEventHandler, MouseEventHandler } from 'react';
-import { DataTableColumn, DataTableProps, ExpandedRowCollapseProps } from './DataTable.props';
+import { DataTableColumn, ExpandedRowCollapseProps } from './DataTable.props';
 import DataTableRowCell from './DataTableRowCell';
 
 const useStyles = createStyles((theme) => {
@@ -78,13 +78,13 @@ interface DataTableRowProps<T> {
   onContextMenu: MouseEventHandler<HTMLTableRowElement> | undefined;
   contextMenuVisible: boolean;
   leftShadowVisible: boolean;
-};
+}
 
 interface DataTableRowParentProps<T> extends DataTableRowProps<T> {
   expandedRow: ((record: T) => React.ReactNode) | undefined;
   isExpanded: boolean;
   collapseProps: ExpandedRowCollapseProps;
-};
+}
 
 export default function DataTableRowParent<T>({
   record,
@@ -98,7 +98,7 @@ export default function DataTableRowParent<T>({
   leftShadowVisible,
   expandedRow,
   isExpanded,
-  collapseProps
+  collapseProps,
 }: DataTableRowParentProps<T>) {
   const dataTableRow = DataTableRow({
     record,
@@ -109,11 +109,11 @@ export default function DataTableRowParent<T>({
     onClick,
     onContextMenu,
     contextMenuVisible,
-    leftShadowVisible
+    leftShadowVisible,
   });
 
   if (expandedRow) {
-    const {animateOpacity, transitionDuration, transitionTimingFunction} = collapseProps;
+    const { animateOpacity, transitionDuration, transitionTimingFunction } = collapseProps;
     return (
       <>
         {dataTableRow}
@@ -127,8 +127,7 @@ export default function DataTableRowParent<T>({
         </Collapse>
       </>
     );
-  }
-  else {
+  } else {
     return dataTableRow;
   }
 }

--- a/package/DataTableRow.tsx
+++ b/package/DataTableRow.tsx
@@ -65,6 +65,12 @@ const useStyles = createStyles((theme) => {
         },
       },
     },
+    expandedRow: {
+      padding: '0 !important',
+    },
+    expandedRow__collapsed: {
+      border: '0 !important',
+    },
   };
 });
 
@@ -105,7 +111,7 @@ export default function DataTableRowParent<T>({
   collapseProps,
 }: DataTableRowParentProps<T>) {
   const styles = useStyles();
-  const { classes } = styles;
+  const { cx, classes } = styles;
 
   const dataTableRow = DataTableRow({
     record,
@@ -127,15 +133,18 @@ export default function DataTableRowParent<T>({
       <>
         {dataTableRow}
         <tr>
-          <td colSpan={columnCount} className={classes.expandedRow}>
-        <Collapse
-          in={isExpanded}
-          animateOpacity={animateOpacity}
-          transitionDuration={transitionDuration}
-          transitionTimingFunction={transitionTimingFunction}
-        >
-          {expandedRow(record)}
-        </Collapse>
+          <td
+            colSpan={columnCount}
+            className={cx(classes.expandedRow, { [classes.expandedRow__collapsed]: !isExpanded })}
+          >
+            <Collapse
+              in={isExpanded}
+              animateOpacity={animateOpacity}
+              transitionDuration={transitionDuration}
+              transitionTimingFunction={transitionTimingFunction}
+            >
+              {expandedRow(record)}
+            </Collapse>
           </td>
         </tr>
       </>


### PR DESCRIPTION
Here is my first stab at implementing the functionality discussed in #28. Allows the consumer to pass in any custom component. That custom component is passed to the new `DataTableRowParent` wrappers around each `DataTableRow` and will be rendered beneath the row if `isExpanded` is set. 
`isExpanded` is calculated in the `DataTable` itself.
The custom component is wrapped in a [Collapse](https://mantine.dev/core/collapse/) component from `@mantine/core`. The expansion animation behaviour can be customized via the `expandedRow.collapseProps` property.


Please let me know what you think. Should there be more features added? Fewer?

Also please note that this is untested and unlinted. The `build` and `dev` scripts wouldn't work for me - I suspect that may be because I'm on Windows, but I haven't had much of a chance yet to troubleshoot.