### PR TITLE
Implement #23

### DIFF
--- a/package/DataTable.props.ts
+++ b/package/DataTable.props.ts
@@ -9,7 +9,7 @@ import type {
   TableProps,
   PopoverProps,
   PopoverTargetProps,
-  Modal,
+  ModalProps,
 } from '@mantine/core';
 import type { CSSProperties, ReactNode } from 'react';
 import { DataTableHeaderCellBase } from './DataTableHeaderCell';
@@ -403,7 +403,7 @@ export type DataTableProps<T> = {
       /**
        * Props to customize the behaviour of the root `Popover` component
        */
-      popoverProps?: Omit<PopoverProps, 'children' | 'opened' | 'defaultOpened'>;
+      popoverProps?: Partial<Omit<PopoverProps, 'children' | 'opened' | 'defaultOpened'>>;
 
       /**
        * Prop to customize the behaviour of the `Popover.Target` component
@@ -415,7 +415,20 @@ export type DataTableProps<T> = {
      * Pass in a custom `Modal` component instead;
      * ignored if `popover` is set
      */
-    modal?: (headerCellProps: DataTableHeaderCellBase<T>) => typeof Modal;
+    modal?: {
+      /**
+       * Custom component to be rendered
+       */
+      item: (headerCellProps: DataTableHeaderCellBase<T>) => ReactNode;
+
+      /**
+       * Props to customize the behaviour of the `Modal`;
+       * if `modalProps.title` is a function, it will be passed the title of the current column
+       */
+      modalProps?: Partial<Omit<ModalProps, 'opened' | 'children' | 'title'>> & {
+        title: string | ((title: string) => ReactNode)
+      };
+    };
   };
 } & Pick<TableProps, 'striped' | 'highlightOnHover' | 'horizontalSpacing' | 'verticalSpacing' | 'fontSize'> &
   Omit<DefaultProps<'root' | 'header' | 'pagination', CSSProperties>, 'unstyled'> &

--- a/package/DataTable.props.ts
+++ b/package/DataTable.props.ts
@@ -9,10 +9,10 @@ import type {
   TableProps,
   PopoverProps,
   PopoverTargetProps,
-  Modal
+  Modal,
 } from '@mantine/core';
 import type { CSSProperties, ReactNode } from 'react';
-import { DataTableHeaderCellBase } from "./DataTableHeaderCell";
+import { DataTableHeaderCellBase } from './DataTableHeaderCell';
 
 export type DataTableColumnTextAlignment = 'left' | 'center' | 'right';
 export type DataTableVerticalAlignment = 'top' | 'center' | 'bottom';
@@ -403,12 +403,12 @@ export type DataTableProps<T> = {
       /**
        * Props to customize the behaviour of the root `Popover` component
        */
-      popoverProps?: Omit<PopoverProps, 'children' | 'opened' | 'defaultOpened'>,
+      popoverProps?: Omit<PopoverProps, 'children' | 'opened' | 'defaultOpened'>;
 
       /**
        * Prop to customize the behaviour of the `Popover.Target` component
        */
-       popupType?: PopoverTargetProps['popupType'],
+      popupType?: PopoverTargetProps['popupType'];
     };
 
     /**

--- a/package/DataTable.props.ts
+++ b/package/DataTable.props.ts
@@ -426,7 +426,7 @@ export type DataTableProps<T> = {
        * if `modalProps.title` is a function, it will be passed the title of the current column
        */
       modalProps?: Partial<Omit<ModalProps, 'opened' | 'children' | 'title'>> & {
-        title: string | ((title: string) => ReactNode)
+        title: string | ((title: string) => ReactNode);
       };
     };
   };

--- a/package/DataTable.props.ts
+++ b/package/DataTable.props.ts
@@ -7,8 +7,12 @@ import type {
   MantineTheme,
   Sx,
   TableProps,
+  PopoverProps,
+  PopoverTargetProps,
+  Modal
 } from '@mantine/core';
 import type { CSSProperties, ReactNode } from 'react';
+import { DataTableHeaderCellBase } from "./DataTableHeaderCell";
 
 export type DataTableColumnTextAlignment = 'left' | 'center' | 'right';
 export type DataTableVerticalAlignment = 'top' | 'center' | 'bottom';
@@ -381,6 +385,37 @@ export type DataTableProps<T> = {
      * A function returning the row menu items for the current record
      */
     items: (record: T) => DataTableContextMenuItemProps[];
+  };
+
+  /**
+   * Defines a custom component to render when the filter button is clicked
+   */
+  filterButton?: {
+    /**
+     * Render the custom component in a `Popover`
+     */
+    popover?: {
+      /**
+       * Custom component to be rendered
+       */
+      item: (headerCellProps: DataTableHeaderCellBase<T>) => ReactNode;
+
+      /**
+       * Props to customize the behaviour of the root `Popover` component
+       */
+      popoverProps?: Omit<PopoverProps, 'children' | 'opened' | 'defaultOpened'>,
+
+      /**
+       * Prop to customize the behaviour of the `Popover.Target` component
+       */
+       popupType?: PopoverTargetProps['popupType'],
+    };
+
+    /**
+     * Pass in a custom `Modal` component instead;
+     * ignored if `popover` is set
+     */
+    modal?: (headerCellProps: DataTableHeaderCellBase<T>) => typeof Modal;
   };
 } & Pick<TableProps, 'striped' | 'highlightOnHover' | 'horizontalSpacing' | 'verticalSpacing' | 'fontSize'> &
   Omit<DefaultProps<'root' | 'header' | 'pagination', CSSProperties>, 'unstyled'> &

--- a/package/DataTable.tsx
+++ b/package/DataTable.tsx
@@ -122,6 +122,7 @@ export default function DataTable<T>({
   striped,
   onRowClick,
   rowContextMenu,
+  filterButton,
   sx,
   className,
   classNames,
@@ -284,6 +285,7 @@ export default function DataTable<T>({
             }
             leftShadowVisible={selectionVisibleAndNotScrolledToLeft}
             bottomShadowVisible={!scrolledToTop}
+            filterButton={filterButton}
           />
           <tbody>
             {recordsLength ? (

--- a/package/DataTableHeader.tsx
+++ b/package/DataTableHeader.tsx
@@ -1,7 +1,7 @@
 import { Checkbox, createStyles, CSSObject } from '@mantine/core';
 import { CSSProperties, ForwardedRef, forwardRef } from 'react';
 import { DataTableColumn, DataTableProps, DataTableSortStatus } from './DataTable.props';
-import DataTableHeaderCellParent from "./DataTableHeaderCell";
+import DataTableHeaderCellParent from './DataTableHeaderCell';
 
 const useStyles = createStyles((theme) => {
   const shadowGradientAlpha = theme.colorScheme === 'dark' ? 0.5 : 0.05;

--- a/package/DataTableHeader.tsx
+++ b/package/DataTableHeader.tsx
@@ -78,7 +78,6 @@ export default forwardRef(function DataTableHeader<T>(
     selectionIndeterminate,
     onSelectionChange,
     leftShadowVisible,
-    bottomShadowVisible,
     filterButton,
   }: DataTableHeaderProps<T>,
   ref: ForwardedRef<HTMLTableSectionElement>

--- a/package/DataTableHeader.tsx
+++ b/package/DataTableHeader.tsx
@@ -1,7 +1,7 @@
 import { Checkbox, createStyles, CSSObject } from '@mantine/core';
 import { CSSProperties, ForwardedRef, forwardRef } from 'react';
-import { DataTableColumn, DataTableSortStatus } from './DataTable.props';
-import DataTableHeaderCell from './DataTableHeaderCell';
+import { DataTableColumn, DataTableProps, DataTableSortStatus } from './DataTable.props';
+import DataTableHeaderCellParent from "./DataTableHeaderCell";
 
 const useStyles = createStyles((theme) => {
   const shadowGradientAlpha = theme.colorScheme === 'dark' ? 0.5 : 0.05;
@@ -84,6 +84,7 @@ type DataTableHeaderProps<T> = {
   onSelectionChange: (() => void) | undefined;
   leftShadowVisible: boolean;
   bottomShadowVisible: boolean;
+  filterButton: DataTableProps<T>['filterButton'];
 };
 
 export default forwardRef(function DataTableHeader<T>(
@@ -99,6 +100,7 @@ export default forwardRef(function DataTableHeader<T>(
     onSelectionChange,
     leftShadowVisible,
     bottomShadowVisible,
+    filterButton,
   }: DataTableHeaderProps<T>,
   ref: ForwardedRef<HTMLTableSectionElement>
 ) {
@@ -127,7 +129,7 @@ export default forwardRef(function DataTableHeader<T>(
           </th>
         )}
         {columns.map(({ accessor, visibleMediaQuery, textAlignment, width, title, sortable }) => (
-          <DataTableHeaderCell<T>
+          <DataTableHeaderCellParent<T>
             key={accessor}
             accessor={accessor}
             visibleMediaQuery={visibleMediaQuery}
@@ -137,6 +139,7 @@ export default forwardRef(function DataTableHeader<T>(
             sortable={sortable}
             sortStatus={sortStatus}
             onSortStatusChange={onSortStatusChange}
+            filterButton={filterButton}
           />
         ))}
       </tr>

--- a/package/DataTableHeaderCell.tsx
+++ b/package/DataTableHeaderCell.tsx
@@ -1,4 +1,4 @@
-import { Box, Center, createStyles, Group, MantineTheme, Popover } from '@mantine/core';
+import { Box, Center, createStyles, Group, MantineTheme, Popover, Modal } from '@mantine/core';
 import { ReactNode, useState } from 'react';
 import { ArrowDown, ArrowsVertical, Filter, FilterOff } from 'tabler-icons-react';
 import { DataTableColumn, DataTableProps, DataTableSortStatus } from './DataTable.props';
@@ -102,14 +102,14 @@ export default function DataTableHeaderCellParent<T>({
 
   const { popover, modal } = filterButton;
 
-  const onOpen = popover?.popoverProps?.onChange
-    ? (opened: boolean) => {
-        popover.popoverProps!.onChange!(opened);
-        setFilterOpened(opened);
-      }
-    : setFilterOpened;
-
   if (popover) {
+    const onOpen = popover.popoverProps?.onChange
+      ? (opened: boolean) => {
+          popover.popoverProps!.onChange!(opened);
+          setFilterOpened(opened);
+        }
+      : setFilterOpened;
+
     return (
       <Popover
         arrowOffset={popover.popoverProps?.arrowOffset}
@@ -166,15 +166,61 @@ export default function DataTableHeaderCellParent<T>({
       return cellWrapper(dataTableHeaderCell);
     }
 
+    const onClose = modal.modalProps?.onClose
+      ? () => {
+        modal.modalProps!.onClose!();
+        setFilterOpened(false);
+      }
+      : () => setFilterOpened(false);
+
+      const modalTitleProp = modal.modalProps?.title;
+      let modalTitle: string | ReactNode;
+      
+      if (modalTitleProp) {
+        if (typeof modalTitleProp === 'function') modalTitle = modalTitleProp(String(title));
+        else modalTitle = modalTitleProp;
+      }
+      else {
+        modalTitle = title;
+      }
     return (
       <>
-        {modal}
+        <Modal
+          centered={modal.modalProps?.centered}
+          closeButtonLabel={modal.modalProps?.closeButtonLabel}
+          closeOnClickOutside={modal.modalProps?.closeOnClickOutside}
+          closeOnEscape={modal.modalProps?.closeOnEscape}
+          fullScreen={modal.modalProps?.fullScreen}
+          id={modal.modalProps?.id}
+          lockScroll={modal.modalProps?.lockScroll}
+          onClose={onClose}
+          opened={filterOpened}
+          overflow={modal.modalProps?.overflow}
+          overlayBlur={modal.modalProps?.overlayBlur}
+          overlayColor={modal.modalProps?.overlayColor}
+          overlayOpacity={modal.modalProps?.overlayOpacity}
+          padding={modal.modalProps?.padding}
+          radius={modal.modalProps?.radius}
+          shadow={modal.modalProps?.shadow}
+          size={modal.modalProps?.size}
+          target={modal.modalProps?.target}
+          title={modalTitle}
+          transition={modal.modalProps?.transition}
+          transitionDuration={modal.modalProps?.transitionDuration}
+          transitionTimingFunction={modal.modalProps?.transitionTimingFunction}
+          trapFocus={modal.modalProps?.trapFocus}
+          withCloseButton={modal.modalProps?.withCloseButton}
+          withFocusReturn={modal.modalProps?.withFocusReturn}
+          withinPortal={modal.modalProps?.withinPortal}
+          zIndex={modal.modalProps?.zIndex}
+        >
         {cellWrapper(
           <Group position="apart" noWrap spacing={0}>
             {dataTableHeaderCell}
-            {DataTableHeaderFilterButton({ filterOpened, onOpen })}
+            {DataTableHeaderFilterButton({ filterOpened, onOpen: setFilterOpened })}
           </Group>
         )}
+        </Modal>
       </>
     );
   }

--- a/package/DataTableHeaderCell.tsx
+++ b/package/DataTableHeaderCell.tsx
@@ -60,7 +60,7 @@ interface DataTableHeaderCellWrapper<T> extends Pick<DataTableColumn<T>, 'sortab
 
 interface DataTableHeaderFilterButton {
   filterOpened: boolean;
-  onOpen: (opened: boolean) => void;
+  onChange: (opened: boolean) => void;
 }
 
 export default function DataTableHeaderCellParent<T>({
@@ -103,7 +103,7 @@ export default function DataTableHeaderCellParent<T>({
   const { popover, modal } = filterButton;
 
   if (popover) {
-    const onOpen = popover.popoverProps?.onChange
+    const onChange = popover.popoverProps?.onChange
       ? (opened: boolean) => {
           popover.popoverProps!.onChange!(opened);
           setFilterOpened(opened);
@@ -121,7 +121,7 @@ export default function DataTableHeaderCellParent<T>({
         id={popover.popoverProps?.id}
         middlewares={popover.popoverProps?.middlewares}
         offset={popover.popoverProps?.offset}
-        onChange={onOpen}
+        onChange={onChange}
         onClose={popover.popoverProps?.onClose}
         onOpen={popover.popoverProps?.onOpen}
         onPositionChange={popover.popoverProps?.onPositionChange}
@@ -143,7 +143,7 @@ export default function DataTableHeaderCellParent<T>({
           {cellWrapper(
             <Group position="apart" noWrap spacing={0}>
               {dataTableHeaderCell}
-              {DataTableHeaderFilterButton({ filterOpened, onOpen })}
+              {DataTableHeaderFilterButton({ filterOpened, onChange })}
             </Group>
           )}
         </Popover.Target>
@@ -216,7 +216,7 @@ export default function DataTableHeaderCellParent<T>({
           {cellWrapper(
             <Group position="apart" noWrap spacing={0}>
               {dataTableHeaderCell}
-              {DataTableHeaderFilterButton({ filterOpened, onOpen: setFilterOpened })}
+              {DataTableHeaderFilterButton({ filterOpened, onChange: setFilterOpened })}
             </Group>
           )}
         </Modal>
@@ -250,9 +250,9 @@ function DataTableHeaderCellWrapper<T>({
   );
 }
 
-function DataTableHeaderFilterButton({ filterOpened, onOpen }: DataTableHeaderFilterButton) {
+function DataTableHeaderFilterButton({ filterOpened, onChange }: DataTableHeaderFilterButton) {
   return (
-    <Center role="button" onClick={() => onOpen(filterOpened)}>
+    <Center role="button" onClick={() => onChange(filterOpened)}>
       {filterOpened ? <FilterOff size={DATATABLEHEADER_ICONSIZE} /> : <Filter size={DATATABLEHEADER_ICONSIZE} />}
     </Center>
   );

--- a/package/DataTableHeaderCell.tsx
+++ b/package/DataTableHeaderCell.tsx
@@ -168,21 +168,20 @@ export default function DataTableHeaderCellParent<T>({
 
     const onClose = modal.modalProps?.onClose
       ? () => {
-        modal.modalProps!.onClose!();
-        setFilterOpened(false);
-      }
+          modal.modalProps!.onClose!();
+          setFilterOpened(false);
+        }
       : () => setFilterOpened(false);
 
-      const modalTitleProp = modal.modalProps?.title;
-      let modalTitle: string | ReactNode;
-      
-      if (modalTitleProp) {
-        if (typeof modalTitleProp === 'function') modalTitle = modalTitleProp(String(title));
-        else modalTitle = modalTitleProp;
-      }
-      else {
-        modalTitle = title;
-      }
+    const modalTitleProp = modal.modalProps?.title;
+    let modalTitle: string | ReactNode;
+
+    if (modalTitleProp) {
+      if (typeof modalTitleProp === 'function') modalTitle = modalTitleProp(String(title));
+      else modalTitle = modalTitleProp;
+    } else {
+      modalTitle = title;
+    }
     return (
       <>
         <Modal
@@ -214,12 +213,12 @@ export default function DataTableHeaderCellParent<T>({
           withinPortal={modal.modalProps?.withinPortal}
           zIndex={modal.modalProps?.zIndex}
         >
-        {cellWrapper(
-          <Group position="apart" noWrap spacing={0}>
-            {dataTableHeaderCell}
-            {DataTableHeaderFilterButton({ filterOpened, onOpen: setFilterOpened })}
-          </Group>
-        )}
+          {cellWrapper(
+            <Group position="apart" noWrap spacing={0}>
+              {dataTableHeaderCell}
+              {DataTableHeaderFilterButton({ filterOpened, onOpen: setFilterOpened })}
+            </Group>
+          )}
         </Modal>
       </>
     );


### PR DESCRIPTION
I took a stab at implementing the functionality we discussed in #23. The consumer can pass in a custom component to be rendered in a `Popover` as we discussed, but I also added the ability for the consumer to instead pass in a `Modal` if they want.

I did some basic testing and the button at least seems to be rendering properly. I haven't had a chance yet to test the `Popover` and `Modal` functionality, but this might be a busy week so I wanted to create a draft with what I have so far.