### PR TITLE
Keyboard accessibility for sortable header cells

### DIFF
--- a/package/DataTableHeaderCell.tsx
+++ b/package/DataTableHeaderCell.tsx
@@ -104,7 +104,7 @@ export default function DataTableHeaderCell<T>({
                 className={cx(classes.sortableColumnHeaderIcon, {
                   [classes.sortableColumnHeaderIconRotated]: sortStatus.direction === 'desc',
                 })}
-                ariaLabel={`Sorted ${sortStatus.direction === 'desc' ? 'descending' : 'ascending'}`}
+                aria-label={`Sorted ${sortStatus.direction === 'desc' ? 'descending' : 'ascending'}`}
                 size={14}
               />
             ) : (

--- a/package/DataTableHeaderCell.tsx
+++ b/package/DataTableHeaderCell.tsx
@@ -66,6 +66,14 @@ export default function DataTableHeaderCell<T>({
   if (!useMediaQueryStringOrFunction(visibleMediaQuery)) return null;
   const text = title ?? humanize(accessor);
   const tooltip = typeof text === 'string' ? text : undefined;
+  const sortAction = sortable && onSortStatusChange
+    ? () => {
+        onSortStatusChange({
+          columnAccessor: accessor,
+          direction: sortStatus?.direction === 'asc' ? 'desc' : 'asc',
+        });
+      }
+    : undefined;
   return (
     <Box
       component="th"
@@ -81,16 +89,9 @@ export default function DataTableHeaderCell<T>({
       ]}
       style={style}
       role={sortable ? 'button' : undefined}
-      onClick={
-        sortable && onSortStatusChange
-          ? () => {
-              onSortStatusChange({
-                columnAccessor: accessor,
-                direction: sortStatus?.direction === 'asc' ? 'desc' : 'asc',
-              });
-            }
-          : undefined
-      }
+      tabIndex={sortable ? 0 : undefined}
+      onClick={sortAction}
+      onKeyDown={(e) => e.key === 'Enter' && sortAction()}
     >
       {sortable || sortStatus?.columnAccessor === accessor ? (
         <Group className={classes.sortableColumnHeaderGroup} position="apart" noWrap>
@@ -103,6 +104,7 @@ export default function DataTableHeaderCell<T>({
                 className={cx(classes.sortableColumnHeaderIcon, {
                   [classes.sortableColumnHeaderIconRotated]: sortStatus.direction === 'desc',
                 })}
+                ariaLabel={`Sorted ${sortStatus.direction === 'desc' ? 'descending' : 'ascending'}`}
                 size={14}
               />
             ) : (


### PR DESCRIPTION
Users can alter the tbody cell rendering to add accessibility features, but the header row is not customizable. This patch allows end users to sort using only keyboard controls.

If English text on the IconArrowUp ariaLabel is undesirable in the interest of keeping the component language-independent, ↑ and ↓ can be used for a slightly degraded experience; this is fine for anything converting it to text, but I've confirmed that screen readers still say "up arrow" and "down arrow" for these glyphs regardless of the language selected, so I'm not sure it's ultimately any better.