### PR TITLE
Add slots for "filter" in column header

### DIFF
--- a/package/DataTableHeader.tsx
+++ b/package/DataTableHeader.tsx
@@ -74,6 +74,8 @@ export default forwardRef(function DataTableHeader<T>(
             titleClassName,
             titleStyle,
             titleSx,
+            filter,
+            filtering,
           }) =>
             hidden ? null : (
               <DataTableHeaderCell<T>
@@ -90,6 +92,8 @@ export default forwardRef(function DataTableHeader<T>(
                 sortStatus={sortStatus}
                 sortIcons={sortIcons}
                 onSortStatusChange={onSortStatusChange}
+                filter={filter}
+                filtering={filtering}
               />
             )
         )}

--- a/package/DataTableHeaderCell.tsx
+++ b/package/DataTableHeaderCell.tsx
@@ -1,14 +1,16 @@
-import { Box, Center, createStyles, Group, type MantineTheme, type Sx } from '@mantine/core';
-import { IconArrowsVertical, IconArrowUp } from '@tabler/icons-react';
+import { Box, Center, createStyles, Group, ActionIcon, Popover, Slider, type MantineTheme, type Sx } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { IconArrowsVertical, IconArrowUp, IconFilter } from '@tabler/icons-react';
 import type { CSSProperties, ReactNode } from 'react';
 import type { DataTableColumn, DataTableSortProps } from './types';
 import { humanize, useMediaQueryStringOrFunction } from './utils';
+import { type BaseSyntheticEvent } from 'react';
 
 const useStyles = createStyles((theme) => ({
   sortableColumnHeader: {
     cursor: 'pointer',
     transition: 'background .15s ease',
-    '&:hover': {
+    '&:hover:not(:has(button:hover))': {
       background: theme.colorScheme === 'dark' ? theme.colors.dark[6] : theme.colors.gray[0],
     },
   },
@@ -48,7 +50,22 @@ type DataTableHeaderCellProps<T> = {
   sortStatus: DataTableSortProps['sortStatus'];
   sortIcons: DataTableSortProps['sortIcons'];
   onSortStatusChange: DataTableSortProps['onSortStatusChange'];
-} & Pick<DataTableColumn<T>, 'accessor' | 'sortable' | 'textAlignment' | 'width'>;
+} & Pick<DataTableColumn<T>, 'accessor' | 'sortable' | 'textAlignment' | 'width' | 'filter' | 'filtering'>;
+
+function Filter<T>({ children, isActive }: { children: DataTableColumn<T>['filter'], isActive: boolean }) {
+  const [isOpen, {close, toggle}] = useDisclosure(false);
+
+  return <Popover withArrow withinPortal shadow="md" opened={isOpen} onClose={close} trapFocus>
+    <Popover.Target>
+      <ActionIcon onClick={e => { e.preventDefault(); toggle(); }} variant={isActive ? 'default' : 'subtle'}>
+        <IconFilter size={14} />
+      </ActionIcon>
+    </Popover.Target>
+    <Popover.Dropdown>
+      {typeof children === 'function' ? children({ close }) : children}
+    </Popover.Dropdown>
+  </Popover>
+}
 
 export default function DataTableHeaderCell<T>({
   className,
@@ -63,6 +80,8 @@ export default function DataTableHeaderCell<T>({
   width,
   sortStatus,
   onSortStatusChange,
+  filter,
+  filtering
 }: DataTableHeaderCellProps<T>) {
   const { cx, classes } = useStyles();
   if (!useMediaQueryStringOrFunction(visibleMediaQuery)) return null;
@@ -70,7 +89,8 @@ export default function DataTableHeaderCell<T>({
   const tooltip = typeof text === 'string' ? text : undefined;
   const sortAction =
     sortable && onSortStatusChange
-      ? () => {
+      ? (e?: BaseSyntheticEvent) => {
+          if (e?.defaultPrevented) { return; }
           onSortStatusChange({
             columnAccessor: accessor,
             direction:
@@ -101,32 +121,31 @@ export default function DataTableHeaderCell<T>({
       onClick={sortAction}
       onKeyDown={(e) => e.key === 'Enter' && sortAction?.()}
     >
-      {sortable || sortStatus?.columnAccessor === accessor ? (
-        <Group className={classes.sortableColumnHeaderGroup} position="apart" noWrap>
-          <Box className={cx(classes.columnHeaderText, classes.sortableColumnHeaderText)} title={tooltip}>
-            {text}
-          </Box>
-          {sortStatus?.columnAccessor === accessor ? (
-            <Center
-              className={cx(classes.sortableColumnHeaderIcon, {
-                [classes.sortableColumnHeaderIconRotated]: sortStatus.direction === 'desc',
-              })}
-              role="img"
-              aria-label={`Sorted ${sortStatus.direction === 'desc' ? 'descending' : 'ascending'}`}
-            >
-              {sortIcons?.sorted || <IconArrowUp size={14} />}
-            </Center>
-          ) : (
-            <Center className={classes.sortableColumnHeaderUnsortedIcon} role="img" aria-label="Not sorted">
-              {sortIcons?.unsorted || <IconArrowsVertical size={14} />}
-            </Center>
-          )}
-        </Group>
-      ) : (
-        <Box className={classes.columnHeaderText} title={tooltip}>
+      <Group className={classes.sortableColumnHeaderGroup} position="apart" noWrap>
+        <Box className={cx(classes.columnHeaderText, classes.sortableColumnHeaderText)} title={tooltip}>
           {text}
         </Box>
-      )}
+        {sortable || sortStatus?.columnAccessor === accessor ? (
+            <>
+            {sortStatus?.columnAccessor === accessor ? (
+              <Center
+                className={cx(classes.sortableColumnHeaderIcon, {
+                  [classes.sortableColumnHeaderIconRotated]: sortStatus.direction === 'desc',
+                })}
+                role="img"
+                aria-label={`Sorted ${sortStatus.direction === 'desc' ? 'descending' : 'ascending'}`}
+              >
+                {sortIcons?.sorted || <IconArrowUp size={14} />}
+              </Center>
+            ) : (
+              <Center className={classes.sortableColumnHeaderUnsortedIcon} role="img" aria-label="Not sorted">
+                {sortIcons?.unsorted || <IconArrowsVertical size={14} />}
+              </Center>
+            )}
+            </>
+        ) : null}
+        {filter ? <Filter isActive={!!filtering}>{filter}</Filter> : null}
+      </Group>
     </Box>
   );
 }

--- a/package/package.json
+++ b/package/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@mantine/core": "^6.0.11",
+    "@mantine/dates": "^6.0.11",
     "@mantine/hooks": "^6.0.11",
     "@tabler/icons-react": "^2.19.0",
     "@types/react": "^18.2.6",

--- a/package/types/DataTableColumn.ts
+++ b/package/types/DataTableColumn.ts
@@ -32,12 +32,35 @@ export type DataTableColumn<T> = {
   sortable?: boolean;
 
   /**
-   * If assigned, 
+   * Optional node which provides the user with filtering options.
+   * If present, a filter button will be added to the column's header. Upon clicking that button,
+   * a pop-over will be opened which shows the provided node.
+   * 
+   * Alternatively a method returning a node can be provided. It is provided props with a `close`
+   * method which allows programatically closing the pop-over.
+   * 
+   * ```tsx
+   * // …
+   * columns={[
+   *   { 
+   *     accessor: 'name', 
+   *     filter: ({ close }) => {
+   *       return <Stack>
+   *         <Button onClick={() => { setFilter(undefined); close(); }}>Reset</Button>
+   *       </Stack>
+   *     },
+   *   }
+   * ]}
+   * // …
+   * ```
+   * 
+   * Note: this property only takes care of rendering the node which provides the filtering options.
+   * It is assumed that the actual filtering is performed somewhere in user-land. 
    */
   filter?: ReactNode | ((filterProps: { close: () => void }) => ReactNode);
   
   /**
-   * If true, filter icon will be styled differently to indicate it is in effect.
+   * If true, filter icon will be styled differently to indicate the filter is in effect.
    */
   filtering?: boolean;
 

--- a/package/types/DataTableColumn.ts
+++ b/package/types/DataTableColumn.ts
@@ -32,6 +32,16 @@ export type DataTableColumn<T> = {
   sortable?: boolean;
 
   /**
+   * If assigned, 
+   */
+  filter?: ReactNode | ((filterProps: { close: () => void }) => ReactNode);
+  
+  /**
+   * If true, filter icon will be styled differently to indicate it is in effect.
+   */
+  filtering?: boolean;
+
+  /**
    * Desired column width
    */
   width?: string | number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1585,6 +1585,13 @@
     react-remove-scroll "^2.5.5"
     react-textarea-autosize "8.3.4"
 
+"@mantine/dates@^6.0.11":
+  version "6.0.11"
+  resolved "https://registry.yarnpkg.com/@mantine/dates/-/dates-6.0.11.tgz#768098e9af40686869c9b5a37f5a2e13553498ba"
+  integrity sha512-R0+fZQoTH8ioiAiVA7RFBsO6NL4MPz3d1lin2QCi/rj3ICp/+8X+AG4jN1Uy+xtWgfPB+hjp5RJASyUa0hNqtw==
+  dependencies:
+    "@mantine/utils" "6.0.11"
+
 "@mantine/hooks@^6.0.11":
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/@mantine/hooks/-/hooks-6.0.11.tgz#1f31cc04aaaf1c24509452a263984647a2b494cf"


### PR DESCRIPTION
Related to #144 

This pull-request adds support for showing filtering options in a column's header (or really just any component…). It does **not** add any inherent filtering however; the documentation already provided enough reasoning as to why:

> # Why no built-in “Excel-like” searching and filtering support?
> You’ll often have to implement searching and filtering data in your projects.
> However there’s simply no way for Mantine DataTable to accommodate every possible usage scenario out there. Most of the times you’d have to deal with pagination, sorting, asynchronous loading; sometimes you’d have to place a search box or custom filtering criteria selectors in the header of your entire website/application.
> 
> Not to mention that in real-life you’d most often do the actual filtering and/or searching in a server API.
The responsibilities and areas of control are most of the times spread across your application’s UI and architectural layers, and trying to fit all this in a standard component design and behavior would needlessly constrain the developer.

I have tried to keep the API relatively simple, by adding two props:

- `filter`: A React node which modifies some "external" state which is used for filtering. Doens't have to be limited to a single state variable, and can therefore be as compex as needed.
- `filtering`: Allows the user to indicate whether the filter is in effect. Solely used for styling purposes. 
 
Having the user manage the filter's state (and logic) means we effectively know nothing about, other than what is provided via the relvant props. Though this might sound somewhat like a downside, it really is not. Creating some construction to intercept the filter, correctly interpret when it is active, and have it be generically typed would be quite  challenge. 

```tsx
<DataTable
  records={filteredRecords}
  columns={[
    { 
      accessor: "name", 
      filter: <TextInput value={query} onChange={setQuery} />,
      filtering: query != "",
    },
  ]}
/>
```

**Simple text field**
![image](https://github.com/icflorescu/mantine-datatable/assets/11519728/a2d3b9b3-c2a4-4c20-a773-808e83fcf40e)

**Multi-select**
![image](https://github.com/icflorescu/mantine-datatable/assets/11519728/7e7f0dfe-110e-4719-b59e-eaff10ecdacd)

**Date range**
![image](https://github.com/icflorescu/mantine-datatable/assets/11519728/2096e50c-1ef3-4df5-a0a2-74db4d8b0740)

Some considerations:

- Props could be grouped (`filter={{ active: query != "", component: <>{/*…*/}</>}}`); mostly a matter of taste, doesn't have any major (dis)advantages that I'm aware of.
- Don't highlight headers of sortable columns while over the filter button. Having the styling be something along the lines of "`&:hover:not(:has(button:hover))`" might do the trick, but the browser support is a bit iffy.
- Add some more options for customizing the look of the filter icon and pop-over.