### PR TITLE
Docs website: fix algolia logo color

### DIFF
--- a/docs/pages/docsearch-overrides.css
+++ b/docs/pages/docsearch-overrides.css
@@ -6,3 +6,8 @@
 .DocSearch-Container {
   z-index: 1000;
 }
+
+.DocSearch-Logo .cls-1,
+.DocSearch-Logo .cls-2 {
+  fill: var(--docsearch-logo-color);
+}


### PR DESCRIPTION
This is a temporary fix until https://github.com/algolia/docsearch/pull/1949 gets merged.