### PR TITLE
Relax customRowAttributes & customCellAttributes return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The following is a list of notable changes to the Mantine DataTable component.  
 Minor versions that are not listed in the changelog are bug fixes and small improvements.
 
+## 2.9.0 (2023-07-20)
+
+- Relax `customRowAttributes` & `customCellAttributes` return types to `Record<string, unknown>` in order to support custom event handlers (see [#380](https://github.com/icflorescu/mantine-datatable/discussions/380))
+
 ## 2.8.3 (2023-07-12)
 
 - Fix a bug when filtering popover triggers sorting button (see [#368](https://github.com/icflorescu/mantine-datatable/issues/368))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-The following is a list of notable changes to the Mantine Datatable component.  
+The following is a list of notable changes to the Mantine DataTable component.  
 Minor versions that are not listed in the changelog are bug fixes and small improvements.
 
 ## 2.8.3 (2023-07-12)

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mantine-datatable-docs",
-  "version": "2.8.5",
+  "version": "2.9.0",
   "description": "Docs website for mantine-datatable; see ../package/package.json for more info",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mantine-datatable-turborepo",
-  "version": "2.8.5",
+  "version": "2.9.0",
   "description": "This is a monorepo; see package/package.json for more info",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@babel/preset-react": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
     "@faker-js/faker": "^8.0.2",
-    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.4.3",
@@ -36,7 +36,7 @@
     "jest": "^29.6.0",
     "jest-environment-jsdom": "^29.6.0",
     "prettier": "^3.0.0",
-    "turbo": "^1.10.8",
+    "turbo": "^1.10.9",
     "typescript": "^5.1.6"
   },
   "engines": {

--- a/package/DataTable.tsx
+++ b/package/DataTable.tsx
@@ -465,7 +465,7 @@ export default function DataTable<T>({
                     className={rowClassName}
                     style={rowStyle}
                     sx={rowSx}
-                    customRowAttributes={customRowAttributes}
+                    customAttributes={customRowAttributes}
                     leftShadowVisible={selectionVisibleAndNotScrolledToLeft}
                   />
                 );

--- a/package/DataTableRow.tsx
+++ b/package/DataTableRow.tsx
@@ -52,7 +52,7 @@ type DataTableRowProps<T> = {
   onCellClick: DataTableCellClickHandler<T> | undefined;
   onContextMenu: MouseEventHandler<HTMLTableRowElement> | undefined;
   expansion: ReturnType<typeof useRowExpansion<T>>;
-  customRowAttributes?: (record: T, recordIndex: number) => Record<string, string | number>;
+  customAttributes?: (record: T, recordIndex: number) => Record<string, unknown>;
   className?: string | ((record: T, recordIndex: number) => string | undefined);
   style?: CSSProperties | ((record: T, recordIndex: number) => CSSProperties | undefined);
   sx?: Sx;
@@ -75,7 +75,7 @@ export default function DataTableRow<T>({
   onCellClick,
   onContextMenu,
   expansion,
-  customRowAttributes,
+  customAttributes,
   className,
   style,
   sx,
@@ -111,7 +111,7 @@ export default function DataTableRow<T>({
         }}
         style={typeof style === 'function' ? style(record, recordIndex) : style}
         sx={sx}
-        {...customRowAttributes?.(record, recordIndex)}
+        {...customAttributes?.(record, recordIndex)}
         onContextMenu={onContextMenu}
       >
         {selectionVisible && (

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mantine-datatable",
-  "version": "2.8.5",
+  "version": "2.9.0",
   "description": "The dependency-free datatable component for Mantine UI, featuring asynchronous data loading support, pagination, multple rows selection, column sorting, custom cell data rendering, row context menu, row expansion and more",
   "keywords": [
     "mantine",

--- a/package/types/DataTableColumn.ts
+++ b/package/types/DataTableColumn.ts
@@ -112,9 +112,11 @@ export type DataTableColumn<T> = {
   cellsSx?: Sx;
 
   /**
-   * Optional function returning an object of custom attributes to be applied to each cell in the column
+   * Optional function returning an object of custom attributes to be applied to each cell in the column.
+   * Receives the current record and its index as arguments.
+   * Useful for adding data attributes, handling middle-clicks, etc.
    */
-  customCellAttributes?: (record: T, recordIndex: number) => Record<string, string | number>;
+  customCellAttributes?: (record: T, recordIndex: number) => Record<string, unknown>;
 
   /**
    * Optional column footer content; if at least one column has a footer, the table will display a footer row

--- a/package/types/DataTableProps.ts
+++ b/package/types/DataTableProps.ts
@@ -157,9 +157,11 @@ export type DataTableProps<T> = {
   rowSx?: Sx;
 
   /**
-   * Optional function returning an object of custom attributes to be applied to each row in the table
+   * Optional function returning an object of custom attributes to be applied to each row in the table.
+   * Receives the current record and its index as arguments.
+   * Useful for adding data attributes, handling middle-clicks, etc.
    */
-  customRowAttributes?: (record: T, recordIndex: number) => Record<string, string | number>;
+  customRowAttributes?: (record: T, recordIndex: number) => Record<string, unknown>;
 
   /**
    * Ref pointing to the scrollable viewport element; useful for imperative scrolling

--- a/yarn.lock
+++ b/yarn.lock
@@ -2147,10 +2147,10 @@
     lz-string "^1.5.0"
     pretty-format "^27.0.2"
 
-"@testing-library/jest-dom@^5.16.5":
-  version "5.16.5"
-  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.16.5.tgz#3912846af19a29b2dbf32a6ae9c31ef52580074e"
-  integrity sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==
+"@testing-library/jest-dom@^5.17.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.17.0.tgz#5e97c8f9a15ccf4656da00fecab505728de81e0c"
+  integrity sha512-ynmNeT7asXyH3aSVv4vvX4Rb+0qjOhdNHnO/3vuZNqPmhDpV/+rCSGwQ7bLcmU2cJ4dvoheIO85LQj0IbJHEtg==
   dependencies:
     "@adobe/css-tools" "^4.0.1"
     "@babel/runtime" "^7.9.2"
@@ -6958,47 +6958,47 @@ tsutils@^3.21.0:
   dependencies:
     tslib "^1.8.1"
 
-turbo-darwin-64@1.10.8:
-  version "1.10.8"
-  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.10.8.tgz#62d8f47e42fccb9ddadb69c13c4fad510f9c0585"
-  integrity sha512-FOK3qrLZE2Yq7/2DkAnAzghisGQroZJs85Rui3IXM/2e7rTtBADmU9w36d4k0Yw7RHEiOo8U4eAYUl52OWRwJQ==
+turbo-darwin-64@1.10.9:
+  version "1.10.9"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.10.9.tgz#7b708e8d250556059eac4d00a8095b75ef86a4f5"
+  integrity sha512-Avz3wsYYb8/vjyHPVRFbNbowIiaF33vcBRklIUkPchTLvZekrT5x3ltQBCflyoi2zJV9g08hK4xXTGuCxeVvPA==
 
-turbo-darwin-arm64@1.10.8:
-  version "1.10.8"
-  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.10.8.tgz#537db8024d2a43a5579ac43632fb7c3b18c6cbaf"
-  integrity sha512-8mbgH8oBycusa8RnbHlvrpHxfZsgNrk6CXMu/KJECpajYT3nSOMK2Rrs+422HqLDTVUw4GAqmTr26nUx8yJoyA==
+turbo-darwin-arm64@1.10.9:
+  version "1.10.9"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.10.9.tgz#8fb86e7b094d8b6873cee016f501753108266f9c"
+  integrity sha512-HyggdSPc/v2HuYrJF75smhIlurn8bY2cWpZYCjOL5Pj2DpLyhBs+nk+JirZl7XQiaUEVFj6eTbsejXyDP2Ritw==
 
-turbo-linux-64@1.10.8:
-  version "1.10.8"
-  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.10.8.tgz#58f0fa8bbd1d148443bc787c4458f7821b2650e4"
-  integrity sha512-eJ1ND3LuILw28gd+9f3Ews7Eika9WOxp+/PxJI+EPHseTrbLMLYqSPAunmZdOx840Pq0Sk5j4Nik7NCzuCWXkg==
+turbo-linux-64@1.10.9:
+  version "1.10.9"
+  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.10.9.tgz#2cc21a6d725190cc42b80bd27265727767fc5270"
+  integrity sha512-qvdEgJKzDjOYY8o/HlnSwD+TIXiAML+3l6wUG4Ojuh/6cIhemLMRaHmEG+LygRW7GRw3dDv3hpp9OtiKmyxFdQ==
 
-turbo-linux-arm64@1.10.8:
-  version "1.10.8"
-  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.10.8.tgz#1fbd620fea6fcf778fb55c7d15ffa15243e31ea0"
-  integrity sha512-3+pVaOzGP/5GFvQakxuHDMsj43Y6bmaq5/84tvgGL0FgtKpsQvBfdaDs12HX5cb/zUnd2/jdQPNiGJwVeC/McA==
+turbo-linux-arm64@1.10.9:
+  version "1.10.9"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.10.9.tgz#e4d6e096ff76706a7f0fcf034588975d1c79eaf2"
+  integrity sha512-gva8H3CS8F6HlXL6YTDJAPrvPXVjBCxdd4DKABghjAxdknV5mZV1WWwMuGf0Z2W8qtmNG1XS0Dt2Wrb1ERFnLw==
 
-turbo-windows-64@1.10.8:
-  version "1.10.8"
-  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.10.8.tgz#69de1c5149201a7dfcf3afae4e40331bee7a6a0c"
-  integrity sha512-LdryI+ZQsVrW4hWZw5G5vJz0syjWxyc0tnieZRefy+d9Ti1du/qCYLP0KQRgL9Yuh1klbH/tzmx70upGARgWKQ==
+turbo-windows-64@1.10.9:
+  version "1.10.9"
+  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.10.9.tgz#5bd6c7d261bc287a9186c72add36a7912dad0e73"
+  integrity sha512-OZ+bkSBJIkyl4JBDk8FX2/bOqtrElfXQV/KQ8/ibddB8Clzn/owx9FS1eXGdvttRZ9IJWzPrdFv+k4vbWQfE7w==
 
-turbo-windows-arm64@1.10.8:
-  version "1.10.8"
-  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-1.10.8.tgz#9bb290f3c50c0e5ea0185c6e16fac39eb5385c21"
-  integrity sha512-whHnhM84KIa2Ly/fcw2Ujw2Rr/9wh8ynAdZ9bdvZoZKAbOr3tXKft0tmy50jQ6IsNr6Cj0XD4cuSTKhvqoGtYA==
+turbo-windows-arm64@1.10.9:
+  version "1.10.9"
+  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-1.10.9.tgz#81e0b5bfd35cc580ba331713881971eaf2b847d8"
+  integrity sha512-WhhhioGaePkGdGOIlrOB8LF8400FJUAQcVf8yCTvjzDB+OWn3dJQ3nalFjxH0PlZ17l6TPGt1WvWQiDVXUE4pw==
 
-turbo@^1.10.8:
-  version "1.10.8"
-  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.10.8.tgz#132a3269580378be1c869c51572f790b8e79adec"
-  integrity sha512-lmPKkeRMC/3gjTVxICt93A8zAzjGjbZINdekjzivn4g/rOjpHVNuOuVANU5L4H4R1bzQr8FFvZNQeQaElOjz/Q==
+turbo@^1.10.9:
+  version "1.10.9"
+  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.10.9.tgz#7e514cdb9e350c9fe8df2b65a44d73103d49ed05"
+  integrity sha512-s1ZRRD89NelCYHty1SpV1Elpv2LRrktgcddbZm9oTq1RPNpJFSrrEOAJhNz/w0fxTSjSN1Ey3TWZghjUjgKuzg==
   optionalDependencies:
-    turbo-darwin-64 "1.10.8"
-    turbo-darwin-arm64 "1.10.8"
-    turbo-linux-64 "1.10.8"
-    turbo-linux-arm64 "1.10.8"
-    turbo-windows-64 "1.10.8"
-    turbo-windows-arm64 "1.10.8"
+    turbo-darwin-64 "1.10.9"
+    turbo-darwin-arm64 "1.10.9"
+    turbo-linux-64 "1.10.9"
+    turbo-linux-arm64 "1.10.9"
+    turbo-windows-64 "1.10.9"
+    turbo-windows-arm64 "1.10.9"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
`customRowAttributes` and `customCellAttributes` can now return `Record<string, unknown>` instead of `Record<string, string | number>`.