### PR TITLE
Update to Mantine 7.0.0 and convert useStyles to CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "eslint-config-prettier": "^9.0.0",
     "jest": "^29.6.4",
     "jest-environment-jsdom": "^29.6.4",
+    "postcss": "^8.4.30",
+    "postcss-preset-mantine": "^1.7.0",
+    "postcss-simple-vars": "^7.0.1",
     "prettier": "^3.0.3",
     "turbo": "^1.10.13",
     "typescript": "^5.2.2"

--- a/package/DataTableColumnGroupHeaderCell.tsx
+++ b/package/DataTableColumnGroupHeaderCell.tsx
@@ -8,7 +8,7 @@ type DataTableColumnGroupHeaderCellProps<T> = {
 };
 
 export default function DataTableColumnGroupHeaderCell<T>({
-  group: { id, columns, title, className, style, sx },
+  group: { id, columns, title, className, style },
 }: DataTableColumnGroupHeaderCellProps<T>) {
   const queries = useMemo(() => columns.map(({ visibleMediaQuery }) => visibleMediaQuery), [columns]);
   const visibles = useMediaQueriesStringOrFunction(queries);
@@ -18,7 +18,7 @@ export default function DataTableColumnGroupHeaderCell<T>({
   );
 
   return colSpan > 0 ? (
-    <Box component="th" colSpan={colSpan} className={className} sx={sx} style={style}>
+    <Box component="th" colSpan={colSpan} className={className} style={style}>
       {title ?? humanize(id)}
     </Box>
   ) : null;

--- a/package/DataTableEmptyRow.tsx
+++ b/package/DataTableEmptyRow.tsx
@@ -1,20 +1,9 @@
-import { createStyles } from '@mantine/core';
-
-const useStyles = createStyles({
-  root: {
-    '&&': {
-      background: 'transparent',
-      ':last-of-type td': {
-        borderBottom: 'none',
-      },
-    },
-  },
-});
+import classes from './styles/DataTableEmptyRow.css';
+import cx from 'clsx';
 
 export default function DataTableEmptyRow() {
-  const { classes } = useStyles();
   return (
-    <tr className={classes.root}>
+    <tr className={cx(classes.root)}>
       <td />
     </tr>
   );

--- a/package/DataTableEmptyState.tsx
+++ b/package/DataTableEmptyState.tsx
@@ -1,30 +1,8 @@
-import { Center, createStyles, Text } from '@mantine/core';
+import { Center, Text } from '@mantine/core';
 import { IconDatabaseOff } from '@tabler/icons-react';
 import type { ReactNode } from 'react';
-
-const useStyles = createStyles((theme) => ({
-  root: {
-    position: 'absolute',
-    top: 0,
-    right: 0,
-    bottom: 0,
-    left: 0,
-    flexDirection: 'column',
-    pointerEvents: 'none',
-    color: theme.colorScheme === 'dark' ? theme.colors.dark[3] : theme.colors.gray[6],
-    opacity: 0,
-    transition: 'opacity .15s ease',
-  },
-  active: {
-    opacity: 1,
-  },
-  standardIcon: {
-    fontSize: 0,
-    borderRadius: '50%',
-    padding: theme.spacing.xs,
-    background: theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.colors.gray[2],
-  },
-}));
+import classes from './styles/DataTableEmptyState.css';
+import cx from 'clsx';
 
 type DataTableEmptyStateProps = {
   icon: ReactNode | undefined;
@@ -36,7 +14,6 @@ type DataTableEmptyStateProps = {
 };
 
 export default function DataTableEmptyState({ icon, text, pt, pb, active, children }: DataTableEmptyStateProps) {
-  const { classes, cx } = useStyles();
   return (
     <Center pt={pt} pb={pb} className={cx(classes.root, { [classes.active]: active })}>
       {children || (

--- a/package/DataTableFooter.tsx
+++ b/package/DataTableFooter.tsx
@@ -1,41 +1,15 @@
-import { Box, createStyles, type CSSObject, type MantineTheme } from '@mantine/core';
-import { CSSProperties, forwardRef, type ForwardedRef } from 'react';
+import { Box, useMantineColorScheme, type MantineColorScheme } from '@mantine/core';
+import { forwardRef, type ForwardedRef, CSSProperties } from 'react';
 import DataTableFooterCell from './DataTableFooterCell';
 import DataTableFooterSelectorPlaceholderCell from './DataTableFooterSelectorPlaceholderCell';
 import type { DataTableColumn, DataTableDefaultColumnProps } from './types';
-
-const useStyles = createStyles(
-  (
-    theme,
-    { scrollDiff, borderColor }: { scrollDiff: number; borderColor: string | ((theme: MantineTheme) => string) }
-  ) => {
-    const relative = scrollDiff < 0;
-    const borderColorValue = typeof borderColor === 'function' ? borderColor(theme) : borderColor;
-
-    return {
-      root: {
-        zIndex: 2,
-        position: relative ? 'relative' : 'sticky',
-        bottom: relative ? scrollDiff : -1,
-        background: theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.white,
-        '&& tr th': {
-          borderTopColor: borderColorValue,
-        },
-      },
-      relative: {
-        position: 'relative',
-      },
-      textSelectionDisabled: {
-        userSelect: 'none',
-      },
-    };
-  }
-);
+import classes from './styles/DataTableFooter.css';
+import cx from 'clsx';
 
 type DataTableFooterProps<T> = {
-  borderColor: string | ((theme: MantineTheme) => string);
+  borderColor: string | ((theme: MantineColorScheme) => string);
   className?: string;
-  style?: CSSObject;
+  style?: CSSProperties;
   columns: DataTableColumn<T>[];
   defaultColumnProps: DataTableDefaultColumnProps<T> | undefined;
   selectionVisible: boolean;
@@ -56,10 +30,22 @@ export default forwardRef(function DataTableFooter<T>(
   }: DataTableFooterProps<T>,
   ref: ForwardedRef<HTMLTableSectionElement>
 ) {
-  const { cx, classes } = useStyles({ scrollDiff, borderColor });
+
+  const {colorScheme} = useMantineColorScheme();
+  const relative = scrollDiff < 0;
+  const borderColorValue = typeof borderColor === 'function' ? borderColor(colorScheme) : borderColor;
 
   return (
-    <Box component="tfoot" ref={ref} className={cx(classes.root, className)} style={style as CSSProperties}>
+    <Box component="tfoot" ref={ref} className={cx(classes.root, className)} style={{
+      position: relative ? 'relative' : 'sticky',
+      bottom: relative ? scrollDiff : -1,
+      tr: {
+        th: {
+          borderTopColor: borderColorValue,
+        }
+      },
+      ...style
+    }}>
       <tr>
         {selectionVisible && <DataTableFooterSelectorPlaceholderCell shadowVisible={leftShadowVisible} />}
         {columns.map(({ hidden, ...columnProps }) => {
@@ -73,7 +59,6 @@ export default forwardRef(function DataTableFooter<T>(
             footer,
             footerClassName,
             footerStyle,
-            footerSx,
             noWrap,
             ellipsis,
           } = { ...defaultColumnProps, ...columnProps };
@@ -83,7 +68,6 @@ export default forwardRef(function DataTableFooter<T>(
               key={accessor}
               className={footerClassName}
               style={footerStyle}
-              sx={footerSx}
               visibleMediaQuery={visibleMediaQuery}
               textAlignment={textAlignment}
               width={width}

--- a/package/DataTableFooterCell.tsx
+++ b/package/DataTableFooterCell.tsx
@@ -1,21 +1,12 @@
-import { Box, createStyles, type MantineTheme, type Sx } from '@mantine/core';
+import { Box, type MantineTheme } from '@mantine/core';
 import type { CSSProperties, ReactNode } from 'react';
 import type { DataTableColumn } from './types';
 import { useMediaQueryStringOrFunction } from './utils';
-
-const useStyles = createStyles({
-  noWrap: {
-    whiteSpace: 'nowrap',
-  },
-  ellipsis: {
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
-});
+import classes from './styles/DataTableFooterCell.css';
+import cx from 'clsx';
 
 type DataTableFooterCellProps<T> = {
   className?: string;
-  sx?: Sx;
   style?: CSSProperties;
   visibleMediaQuery: string | ((theme: MantineTheme) => string) | undefined;
   title: ReactNode | undefined;
@@ -23,7 +14,6 @@ type DataTableFooterCellProps<T> = {
 
 export default function DataTableFooterCell<T>({
   className,
-  sx,
   style,
   visibleMediaQuery,
   title,
@@ -32,22 +22,20 @@ export default function DataTableFooterCell<T>({
   textAlignment,
   width,
 }: DataTableFooterCellProps<T>) {
-  const { cx, classes } = useStyles();
   if (!useMediaQueryStringOrFunction(visibleMediaQuery)) return null;
   return (
     <Box
       component="th"
       className={cx({ [classes.noWrap]: noWrap || ellipsis, [classes.ellipsis]: ellipsis }, className)}
-      sx={[
+      style={[
         {
-          '&&': { textAlign: textAlignment },
+          textAlign: textAlignment,
           width,
           minWidth: width,
           maxWidth: width,
         },
-        sx,
+        style
       ]}
-      style={style}
     >
       {title}
     </Box>

--- a/package/DataTableFooterSelectorPlaceholderCell.tsx
+++ b/package/DataTableFooterSelectorPlaceholderCell.tsx
@@ -1,42 +1,7 @@
-import { createStyles, px } from '@mantine/core';
+import classes from './styles/DataTableFooterSelectorPlaceholderCell.css';
+import cx from 'clsx';
 
-const useStyles = createStyles((theme) => {
-  const shadowGradientAlpha = theme.colorScheme === 'dark' ? 0.5 : 0.05;
-  return {
-    root: {
-      position: 'sticky',
-      width: 0,
-      left: 0,
-      background: 'inherit',
-      '&::after': {
-        content: '""',
-        position: 'absolute',
-        top: 0,
-        right: -px(theme.spacing.sm),
-        bottom: 0,
-        borderLeft: `1px solid ${theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]}`,
-        width: theme.spacing.sm,
-        background: `linear-gradient(to right, ${theme.fn.rgba(theme.black, shadowGradientAlpha)}, ${theme.fn.rgba(
-          theme.black,
-          0
-        )}), linear-gradient(to right, ${theme.fn.rgba(theme.black, shadowGradientAlpha)}, ${theme.fn.rgba(
-          theme.black,
-          0
-        )} 30%)`,
-        pointerEvents: 'none',
-        opacity: 0,
-        transition: 'opacity .15s ease',
-      },
-    },
-    shadowVisible: {
-      '&::after': {
-        opacity: 1,
-      },
-    },
-  };
-});
 
 export default function DataTableFooterSelectorPlaceholderCell({ shadowVisible }: { shadowVisible: boolean }) {
-  const { cx, classes } = useStyles();
   return <th className={cx(classes.root, { [classes.shadowVisible]: shadowVisible })}></th>;
 }

--- a/package/DataTableHeader.tsx
+++ b/package/DataTableHeader.tsx
@@ -1,25 +1,14 @@
-import { createStyles, type CSSObject } from '@mantine/core';
 import { forwardRef, type CSSProperties, type ForwardedRef } from 'react';
 import DataTableColumnGroupHeaderCell from './DataTableColumnGroupHeaderCell';
 import DataTableHeaderCell from './DataTableHeaderCell';
 import DataTableHeaderSelectorCell from './DataTableHeaderSelectorCell';
 import type { DataTableColumn, DataTableColumnGroup, DataTableSortProps } from './types';
-
-const useStyles = createStyles((theme) => ({
-  root: {
-    zIndex: 2,
-    position: 'sticky',
-    top: 0,
-    background: theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.white,
-  },
-  textSelectionDisabled: {
-    userSelect: 'none',
-  },
-}));
+import classes from './styles/DataTableHeader.css';
+import cx from 'clsx';
 
 type DataTableHeaderProps<T> = {
   className?: string;
-  style?: CSSObject;
+  style?: CSSProperties;
   sortStatus: DataTableSortProps['sortStatus'];
   sortIcons: DataTableSortProps['sortIcons'];
   onSortStatusChange: DataTableSortProps['onSortStatusChange'];
@@ -53,8 +42,6 @@ export default forwardRef(function DataTableHeader<T>(
   }: DataTableHeaderProps<T>,
   ref: ForwardedRef<HTMLTableSectionElement>
 ) {
-  const { classes, cx } = useStyles();
-
   const allRecordsSelectorCell = selectionVisible ? (
     <DataTableHeaderSelectorCell
       shadowVisible={leftShadowVisible}
@@ -90,7 +77,6 @@ export default forwardRef(function DataTableHeader<T>(
             sortable,
             titleClassName,
             titleStyle,
-            titleSx,
             filter,
             filtering,
           } = { ...defaultColumnProps, ...columnProps };
@@ -101,7 +87,6 @@ export default forwardRef(function DataTableHeader<T>(
               accessor={accessor}
               className={titleClassName}
               style={titleStyle}
-              sx={titleSx}
               visibleMediaQuery={visibleMediaQuery}
               textAlignment={textAlignment}
               width={width}

--- a/package/DataTableHeaderCell.tsx
+++ b/package/DataTableHeaderCell.tsx
@@ -1,48 +1,14 @@
-import { Box, Center, Group, createStyles, type MantineTheme, type Sx } from '@mantine/core';
+import { Box, Center, Group, type MantineTheme } from '@mantine/core';
 import { IconArrowUp, IconArrowsVertical } from '@tabler/icons-react';
 import type { BaseSyntheticEvent, CSSProperties, ReactNode } from 'react';
 import DataTableHeaderCellFilter from './DataTableHeaderCellFilter';
 import type { DataTableColumn, DataTableSortProps } from './types';
 import { humanize, useMediaQueryStringOrFunction } from './utils';
-
-const useStyles = createStyles((theme) => ({
-  sortableColumnHeader: {
-    cursor: 'pointer',
-    transition: 'background .15s ease',
-    '&:hover:not(:has(button:hover))': {
-      background: theme.colorScheme === 'dark' ? theme.colors.dark[6] : theme.colors.gray[0],
-    },
-  },
-  sortableColumnHeaderGroup: {
-    gap: '0.25em',
-  },
-  columnHeaderText: {
-    overflow: 'hidden',
-    whiteSpace: 'nowrap',
-    textOverflow: 'ellipsis',
-  },
-  sortableColumnHeaderText: {
-    minWidth: 0,
-    flexGrow: 1,
-  },
-  sortableColumnHeaderIcon: {
-    transition: 'transform .15s ease',
-  },
-  sortableColumnHeaderIconRotated: {
-    transform: 'rotate3d(0, 0, 1, 180deg)',
-  },
-  sortableColumnHeaderUnsortedIcon: {
-    color: theme.colorScheme === 'dark' ? theme.colors.dark[3] : theme.colors.gray[5],
-    transition: 'color .15s ease',
-    'th:hover &': {
-      color: theme.colorScheme === 'dark' ? theme.colors.dark[2] : theme.colors.gray[6],
-    },
-  },
-}));
+import classes from './styles/DataTableHeaderCell.css';
+import cx from 'clsx';
 
 type DataTableHeaderCellProps<T> = {
   className?: string;
-  sx?: Sx;
   style?: CSSProperties;
   visibleMediaQuery: string | ((theme: MantineTheme) => string) | undefined;
   title: ReactNode | undefined;
@@ -53,7 +19,6 @@ type DataTableHeaderCellProps<T> = {
 
 export default function DataTableHeaderCell<T>({
   className,
-  sx,
   style,
   accessor,
   visibleMediaQuery,
@@ -67,7 +32,6 @@ export default function DataTableHeaderCell<T>({
   filter,
   filtering,
 }: DataTableHeaderCellProps<T>) {
-  const { cx, classes } = useStyles();
   if (!useMediaQueryStringOrFunction(visibleMediaQuery)) return null;
   const text = title ?? humanize(accessor);
   const tooltip = typeof text === 'string' ? text : undefined;
@@ -91,22 +55,21 @@ export default function DataTableHeaderCell<T>({
     <Box
       component="th"
       className={cx({ [classes.sortableColumnHeader]: sortable }, className)}
-      sx={[
+      style={[
         {
-          '&&': { textAlign: textAlignment },
+          textAlign: textAlignment,
           width,
           minWidth: width,
           maxWidth: width,
         },
-        sx,
+        style,
       ]}
-      style={style}
       role={sortable ? 'button' : undefined}
       tabIndex={sortable ? 0 : undefined}
       onClick={sortAction}
       onKeyDown={(e) => e.key === 'Enter' && sortAction?.()}
     >
-      <Group className={classes.sortableColumnHeaderGroup} position="apart" noWrap>
+      <Group className={classes.sortableColumnHeaderGroup} justify="apart">
         <Box className={cx(classes.columnHeaderText, classes.sortableColumnHeaderText)} title={tooltip}>
           {text}
         </Box>

--- a/package/DataTableHeaderSelectorCell.tsx
+++ b/package/DataTableHeaderSelectorCell.tsx
@@ -1,43 +1,6 @@
-import { Checkbox, createStyles, px } from '@mantine/core';
-
-const useStyles = createStyles((theme) => {
-  const shadowGradientAlpha = theme.colorScheme === 'dark' ? 0.5 : 0.05;
-  return {
-    root: {
-      position: 'sticky',
-      width: 0,
-      left: 0,
-      background: 'inherit',
-      '&::after': {
-        content: '""',
-        position: 'absolute',
-        top: 0,
-        right: -px(theme.spacing.sm),
-        bottom: 0,
-        borderLeft: `1px solid ${theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]}`,
-        width: theme.spacing.sm,
-        background: `linear-gradient(to right, ${theme.fn.rgba(theme.black, shadowGradientAlpha)}, ${theme.fn.rgba(
-          theme.black,
-          0
-        )}), linear-gradient(to right, ${theme.fn.rgba(theme.black, shadowGradientAlpha)}, ${theme.fn.rgba(
-          theme.black,
-          0
-        )} 30%)`,
-        pointerEvents: 'none',
-        opacity: 0,
-        transition: 'opacity .15s ease',
-      },
-    },
-    shadowVisible: {
-      '&::after': {
-        opacity: 1,
-      },
-    },
-    checkboxInput: {
-      cursor: 'pointer',
-    },
-  };
-});
+import { Checkbox } from '@mantine/core';
+import classes from './styles/DataTableHeaderSelectorCell.css';
+import cx from 'clsx';
 
 type DataTableHeaderSelectorCellProps = {
   shadowVisible: boolean;
@@ -56,7 +19,6 @@ export default function DataTableHeaderSelectorCell({
   onChange,
   rowSpan,
 }: DataTableHeaderSelectorCellProps) {
-  const { cx, classes } = useStyles();
   return (
     <th className={cx(classes.root, { [classes.shadowVisible]: shadowVisible })} rowSpan={rowSpan}>
       <Checkbox

--- a/package/DataTableLoader.tsx
+++ b/package/DataTableLoader.tsx
@@ -1,31 +1,14 @@
 import {
   Center,
-  createStyles,
   Loader,
   type DefaultMantineColor,
-  type MantineNumberSize,
   type MantineTheme,
+  MantineSize,
 } from '@mantine/core';
 import type { ReactNode } from 'react';
+import classes from './styles/DataTableLoader.css';
+import cx from 'clsx';
 
-const useStyles = createStyles((theme) => ({
-  root: {
-    zIndex: 3,
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    pointerEvents: 'none',
-    background: theme.fn.rgba(theme.colorScheme === 'dark' ? theme.colors.dark[8] : theme.white, 0.75),
-    opacity: 0,
-    transition: 'opacity .15s ease',
-  },
-  fetching: {
-    pointerEvents: 'all',
-    opacity: 1,
-  },
-}));
 
 type DataTableLoaderProps = {
   pt: number;
@@ -33,7 +16,7 @@ type DataTableLoaderProps = {
   fetching: boolean | undefined;
   customContent: ReactNode | undefined;
   backgroundBlur: number | undefined;
-  size: MantineNumberSize | undefined;
+  size: MantineSize | undefined;
   variant: MantineTheme['loader'] | undefined;
   color: DefaultMantineColor | undefined;
 };
@@ -48,15 +31,14 @@ export default function DataTableLoader({
   variant,
   color,
 }: DataTableLoaderProps) {
-  const { classes, cx } = useStyles();
   return (
     <Center
       pt={pt}
       pb={pb}
       className={cx(classes.root, { [classes.fetching]: fetching })}
-      sx={backgroundBlur ? { backdropFilter: `blur(${backgroundBlur}px)` } : undefined}
+      style={backgroundBlur ? { backdropFilter: `blur(${backgroundBlur}px)` } : undefined}
     >
-      {fetching && (customContent || <Loader size={size} variant={variant} color={color} />)}
+      {fetching && (customContent || <Loader size={size} type={variant} color={color} />)}
     </Center>
   );
 }

--- a/package/DataTablePageSizeSelector.tsx
+++ b/package/DataTablePageSizeSelector.tsx
@@ -1,4 +1,4 @@
-import { Button, Group, Menu, Text, type MantineColor, type MantineSize } from '@mantine/core';
+import { Button, Group, Menu, Text, type MantineColor, type MantineSize, useMantineTheme } from '@mantine/core';
 
 type DataTablePageSizeSelectorComponentProps = {
   size: MantineSize;
@@ -19,21 +19,22 @@ export default function DataTablePageSizeSelector({
   onChange,
   color,
 }: DataTablePageSizeSelectorComponentProps) {
+  const theme = useMantineTheme();
   return (
-    <Group spacing="xs">
+    <Group gap="xs">
       <Text size={size}>{label}</Text>
       <Menu withinPortal withArrow>
         <Menu.Target>
           <Button
             size={size}
             variant="default"
-            sx={[
+            style={[
               { fontWeight: 'normal' },
-              (theme) => ({
+              {
                 height: HEIGHT[size],
                 paddingLeft: theme.spacing[size],
                 paddingRight: theme.spacing[size],
-              }),
+              },
             ]}
           >
             {value}
@@ -45,14 +46,12 @@ export default function DataTablePageSizeSelector({
             return (
               <Menu.Item
                 key={v}
-                sx={[
+                style={[
                   { height: HEIGHT[size] },
-                  (theme) => ({
-                    '&&': {
-                      color: isCurrent ? theme.white : undefined,
-                    },
+                  {
+                    color: isCurrent ? theme.white : undefined,
                     background: isCurrent ? theme.colors[color || theme.primaryColor][6] : undefined,
-                  }),
+                  },
                 ]}
                 disabled={isCurrent}
                 onClick={() => onChange(v)}

--- a/package/DataTablePagination.tsx
+++ b/package/DataTablePagination.tsx
@@ -2,46 +2,16 @@ import {
   Box,
   Pagination,
   Text,
-  createStyles,
-  type CSSObject,
-  type MantineNumberSize,
-  type MantineTheme,
+  type MantineColorScheme,
+  MantineSpacing,
+  useMantineColorScheme,
 } from '@mantine/core';
 import { forwardRef, type CSSProperties, type ForwardedRef, type ReactNode } from 'react';
 import DataTablePageSizeSelector from './DataTablePageSizeSelector';
 import type { DataTablePaginationProps } from './types';
 import type { WithOptional, WithRequired } from './types/utils';
-
-const useStyles = createStyles(
-  (
-    theme,
-    {
-      topBorderColor,
-      paginationWrapBreakpoint,
-    }: { topBorderColor: string | ((theme: MantineTheme) => string); paginationWrapBreakpoint: MantineNumberSize }
-  ) => ({
-    root: {
-      background: theme.colorScheme === 'dark' ? theme.colors.dark[7] : theme.white,
-      borderTop: `1px solid ${typeof topBorderColor === 'function' ? topBorderColor(theme) : topBorderColor}`,
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      gap: theme.spacing.xs,
-      [theme.fn.largerThan(paginationWrapBreakpoint)]: { flexDirection: 'row' },
-    },
-    text: {
-      flex: '1 1 auto',
-    },
-    pagination: {
-      opacity: 1,
-      transition: 'opacity .15s ease',
-    },
-    paginationFetching: {
-      opacity: 0,
-    },
-  })
-);
+import classes from './style/DataTablePagination.css';
+import cx from 'clsx';
 
 type DataTablePaginationComponentProps = WithOptional<
   WithRequired<
@@ -51,11 +21,11 @@ type DataTablePaginationComponentProps = WithOptional<
   'onRecordsPerPageChange' | 'recordsPerPageOptions'
 > & {
   className?: string;
-  style?: CSSObject;
-  topBorderColor: string | ((theme: MantineTheme) => string);
+  style?: CSSProperties;
+  topBorderColor: string | ((theme: MantineColorScheme) => string);
   fetching: boolean | undefined;
   recordsLength: number | undefined;
-  horizontalSpacing: MantineNumberSize | undefined;
+  horizontalSpacing: MantineSpacing | undefined;
   noRecordsText: string;
 };
 
@@ -79,7 +49,6 @@ export default forwardRef(function DataTablePagination(
     recordsPerPageOptions,
     recordsLength,
     horizontalSpacing,
-    paginationWrapBreakpoint,
     getPaginationControlProps,
   }: DataTablePaginationComponentProps,
   ref: ForwardedRef<HTMLDivElement>
@@ -95,7 +64,7 @@ export default forwardRef(function DataTablePagination(
     paginationTextValue = paginationText!({ from, to, totalRecords });
   }
 
-  const { classes, cx } = useStyles({ topBorderColor, paginationWrapBreakpoint });
+  const {colorScheme} = useMantineColorScheme();
 
   return (
     <Box
@@ -103,7 +72,7 @@ export default forwardRef(function DataTablePagination(
       px={horizontalSpacing ?? 'xs'}
       py="xs"
       className={cx(classes.root, className)}
-      style={style as CSSProperties}
+      style={{borderTop: `1px solid ${typeof topBorderColor === 'function' ? topBorderColor(colorScheme) : topBorderColor}`, ...style}}
     >
       <Text className={classes.text} size={paginationSize}>
         {paginationTextValue}

--- a/package/DataTablePagination.tsx
+++ b/package/DataTablePagination.tsx
@@ -10,7 +10,7 @@ import { forwardRef, type CSSProperties, type ForwardedRef, type ReactNode } fro
 import DataTablePageSizeSelector from './DataTablePageSizeSelector';
 import type { DataTablePaginationProps } from './types';
 import type { WithOptional, WithRequired } from './types/utils';
-import classes from './style/DataTablePagination.css';
+import classes from './styles/DataTablePagination.css';
 import cx from 'clsx';
 
 type DataTablePaginationComponentProps = WithOptional<

--- a/package/DataTableRow.tsx
+++ b/package/DataTableRow.tsx
@@ -1,41 +1,12 @@
-import { Box, createStyles, type Sx } from '@mantine/core';
+import { Box } from '@mantine/core';
 import type { ChangeEventHandler, CSSProperties, MouseEventHandler, ReactNode } from 'react';
 import DataTableRowCell from './DataTableRowCell';
 import DataTableRowExpansion from './DataTableRowExpansion';
 import DataTableRowSelectorCell from './DataTableRowSelectorCell';
 import { useRowExpansion } from './hooks';
 import type { DataTableCellClickHandler, DataTableColumn, DataTableDefaultColumnProps } from './types';
-
-const useStyles = createStyles((theme) => {
-  const baseColor = theme.colors[theme.primaryColor][6];
-  return {
-    withPointerCursor: {
-      cursor: 'pointer',
-    },
-    selected: {
-      '&&': {
-        'tr&': {
-          background: theme.colorScheme === 'dark' ? theme.fn.darken(baseColor, 0.6) : theme.fn.lighten(baseColor, 0.9),
-        },
-        'table[data-striped] tbody &:nth-of-type(odd)': {
-          background:
-            theme.colorScheme === 'dark' ? theme.fn.darken(baseColor, 0.55) : theme.fn.lighten(baseColor, 0.85),
-        },
-      },
-    },
-    contextMenuVisible: {
-      '&&': {
-        'tr&': {
-          background: theme.colorScheme === 'dark' ? theme.fn.darken(baseColor, 0.5) : theme.fn.lighten(baseColor, 0.7),
-        },
-        'table[data-striped] tbody &:nth-of-type(odd)': {
-          background:
-            theme.colorScheme === 'dark' ? theme.fn.darken(baseColor, 0.45) : theme.fn.lighten(baseColor, 0.65),
-        },
-      },
-    },
-  };
-});
+import classes from './styles./DataTableRow.css';
+import cx from 'clsx';
 
 type DataTableRowProps<T> = {
   record: T;
@@ -55,7 +26,6 @@ type DataTableRowProps<T> = {
   customAttributes?: (record: T, recordIndex: number) => Record<string, unknown>;
   className?: string | ((record: T, recordIndex: number) => string | undefined);
   style?: CSSProperties | ((record: T, recordIndex: number) => CSSProperties | undefined);
-  sx?: Sx;
   contextMenuVisible: boolean;
   leftShadowVisible: boolean;
 };
@@ -78,11 +48,9 @@ export default function DataTableRow<T>({
   customAttributes,
   className,
   style,
-  sx,
   contextMenuVisible,
   leftShadowVisible,
 }: DataTableRowProps<T>) {
-  const { cx, classes } = useStyles();
 
   return (
     <>
@@ -110,7 +78,6 @@ export default function DataTableRow<T>({
           onClick?.(e);
         }}
         style={typeof style === 'function' ? style(record, recordIndex) : style}
-        sx={sx}
         {...customAttributes?.(record, recordIndex)}
         onContextMenu={onContextMenu}
       >
@@ -152,7 +119,6 @@ export default function DataTableRow<T>({
               key={accessor}
               className={typeof cellsClassName === 'function' ? cellsClassName(record, recordIndex) : cellsClassName}
               style={typeof cellsStyle === 'function' ? cellsStyle(record, recordIndex) : cellsStyle}
-              sx={cellsSx}
               visibleMediaQuery={visibleMediaQuery}
               record={record}
               recordIndex={recordIndex}

--- a/package/DataTableRow.tsx
+++ b/package/DataTableRow.tsx
@@ -5,7 +5,7 @@ import DataTableRowExpansion from './DataTableRowExpansion';
 import DataTableRowSelectorCell from './DataTableRowSelectorCell';
 import { useRowExpansion } from './hooks';
 import type { DataTableCellClickHandler, DataTableColumn, DataTableDefaultColumnProps } from './types';
-import classes from './styles./DataTableRow.css';
+import classes from './styles/DataTableRow.css';
 import cx from 'clsx';
 
 type DataTableRowProps<T> = {

--- a/package/DataTableRowCell.tsx
+++ b/package/DataTableRowCell.tsx
@@ -1,24 +1,12 @@
-import { Box, createStyles, type Sx } from '@mantine/core';
+import { Box } from '@mantine/core';
 import type { CSSProperties, MouseEventHandler, ReactNode } from 'react';
 import type { DataTableColumn } from './types';
 import { getValueAtPath, useMediaQueryStringOrFunction } from './utils';
-
-const useStyles = createStyles({
-  withPointerCursor: {
-    cursor: 'pointer',
-  },
-  noWrap: {
-    whiteSpace: 'nowrap',
-  },
-  ellipsis: {
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-  },
-});
+import classes from './styles/DataTableRowCell.css';
+import cx from 'clsx';
 
 type DataTableRowCellProps<T> = {
   className?: string;
-  sx?: Sx;
   style?: CSSProperties;
   record: T;
   recordIndex: number;
@@ -38,7 +26,6 @@ type DataTableRowCellProps<T> = {
 
 export default function DataTableRowCell<T>({
   className,
-  sx,
   style,
   visibleMediaQuery,
   record,
@@ -53,7 +40,6 @@ export default function DataTableRowCell<T>({
   defaultRender,
   customCellAttributes,
 }: DataTableRowCellProps<T>) {
-  const { cx, classes } = useStyles();
   if (!useMediaQueryStringOrFunction(visibleMediaQuery)) return null;
   return (
     <Box
@@ -62,16 +48,15 @@ export default function DataTableRowCell<T>({
         { [classes.noWrap]: noWrap || ellipsis, [classes.ellipsis]: ellipsis, [classes.withPointerCursor]: onClick },
         className
       )}
-      sx={[
+      style={[
         {
+          ...style,
           width,
           minWidth: width,
           maxWidth: width,
           textAlign: textAlignment,
-        },
-        sx,
+        }
       ]}
-      style={style}
       onClick={onClick}
       {...customCellAttributes?.(record, recordIndex)}
     >

--- a/package/DataTableRowExpansion.tsx
+++ b/package/DataTableRowExpansion.tsx
@@ -1,21 +1,9 @@
-import { Collapse, createStyles } from '@mantine/core';
+import { Collapse } from '@mantine/core';
 import type { ReactNode } from 'react';
 import { useRowExpansionStatus } from './hooks';
 import type { DataTableRowExpansionCollapseProps } from './types';
-
-const useStyles = createStyles({
-  cell: {
-    '&&': {
-      borderBottomWidth: 0,
-      padding: 0,
-    },
-  },
-  expandedCell: {
-    '&&': {
-      borderBottomWidth: 1,
-    },
-  },
-});
+import classes from './styles/DataTableRowExpansion.css';
+import cx from 'clsx';
 
 type DataTableRowExpansionProps = {
   open: boolean;
@@ -26,8 +14,6 @@ type DataTableRowExpansionProps = {
 
 export default function DataTableRowExpansion({ open, colSpan, content, collapseProps }: DataTableRowExpansionProps) {
   const { expanded, visible } = useRowExpansionStatus(open, collapseProps?.transitionDuration);
-
-  const { cx, classes } = useStyles();
 
   return visible ? (
     <>

--- a/package/DataTableRowMenu.tsx
+++ b/package/DataTableRowMenu.tsx
@@ -1,20 +1,13 @@
-import type { MantineNumberSize, MantineShadow } from '@mantine/core';
-import { Paper, createStyles, px } from '@mantine/core';
+import type { MantineRadius, MantineShadow } from '@mantine/core';
+import { Paper, px, useDirection, useMantineTheme } from '@mantine/core';
 import { useClickOutside, useMergedRef, useWindowEvent } from '@mantine/hooks';
 import type { ReactNode } from 'react';
 import { useElementOuterSize } from './hooks';
-
-const useStyles = createStyles((theme) => ({
-  root: {
-    position: 'fixed',
-    border: `1px solid ${theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]}`,
-    overflow: 'hidden',
-    transition: 'all .15s ease',
-  },
-}));
+import classes from './styles/DataTableRowMenu.css';
+import cx from 'clsx';
 
 type DataTableRowMenuProps = {
-  borderRadius: MantineNumberSize | undefined;
+  borderRadius: MantineRadius | undefined;
   shadow: MantineShadow | undefined;
   zIndex: number | undefined;
   y: number;
@@ -40,20 +33,18 @@ export default function DataTableRowMenu({
 
   const { innerWidth: windowWidth, innerHeight: windowHeight } = window;
 
-  const {
-    classes,
-    theme: { dir, spacing },
-  } = useStyles();
+  const theme = useMantineTheme();
+  const { dir } = useDirection();
 
-  const mdSpacing = px(spacing.md);
+  const mdSpacing = px(theme.spacing.md) as number;
 
   return (
     <Paper
       ref={ref}
       shadow={shadow}
       radius={borderRadius}
-      className={classes.root}
-      sx={{
+      className={cx(classes.root)}
+      style={{
         zIndex,
         top: desiredY + height + mdSpacing > windowHeight ? windowHeight - height - mdSpacing : desiredY,
         left:

--- a/package/DataTableRowMenuDivider.tsx
+++ b/package/DataTableRowMenuDivider.tsx
@@ -1,13 +1,6 @@
-import { createStyles } from '@mantine/core';
-
-const useStyles = createStyles((theme) => ({
-  root: {
-    height: 1,
-    background: theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.colors.gray[1],
-  },
-}));
+import classes from './styles/DataTableRowMenuDivider.css';
+import cx from 'clsx';
 
 export default function DataTableRowMenuDivider() {
-  const { classes } = useStyles();
-  return <div className={classes.root} />;
+  return <div className={cx(classes.root)} />;
 }

--- a/package/DataTableRowMenuItem.tsx
+++ b/package/DataTableRowMenuItem.tsx
@@ -1,45 +1,7 @@
-import { Box, Text, UnstyledButton, createStyles, px, type MantineColor } from '@mantine/core';
+import { Box, Text, UnstyledButton, type MantineColor } from '@mantine/core';
 import type { ReactNode } from 'react';
-
-const useStyles = createStyles((theme, { color }: { color?: MantineColor }) => {
-  const verticalPadding = px(theme.spacing.sm) / 2;
-  return {
-    root: {
-      width: '100%',
-      display: 'flex',
-      alignItems: 'center',
-      paddingTop: verticalPadding,
-      paddingBottom: verticalPadding,
-      paddingLeft: theme.spacing.sm,
-      paddingRight: theme.spacing.sm,
-      color: color && theme.colors[color][6],
-      transition: 'background .15s ease',
-      '&[disabled]': {
-        cursor: 'not-allowed',
-        color: theme.colorScheme === 'dark' ? theme.colors.dark[3] : theme.colors.gray[5],
-      },
-      '&:hover:not([disabled])': {
-        background: theme.fn.rgba(
-          color ? theme.colors[color][6] : theme.colorScheme === 'dark' ? theme.colors.dark[3] : theme.colors.gray[4],
-          color ? (theme.colorScheme === 'dark' ? 0.15 : 0.08) : 0.25
-        ),
-      },
-      '&:active:not([disabled])': {
-        background: theme.fn.rgba(
-          color ? theme.colors[color][6] : theme.colorScheme === 'dark' ? theme.colors.dark[3] : theme.colors.gray[4],
-          color ? (theme.colorScheme === 'dark' ? 0.3 : 0.2) : 0.5
-        ),
-      },
-    },
-    icon: {
-      fontSize: 0,
-      marginRight: theme.spacing.xs,
-    },
-    title: {
-      whiteSpace: 'nowrap',
-    },
-  };
-});
+import classes from './styles/DataTableRowMenuItem.css';
+import cx from 'clsx';
 
 type DataTableRowMenuItemProps = {
   icon?: ReactNode;
@@ -50,11 +12,10 @@ type DataTableRowMenuItemProps = {
 };
 
 export default function DataTableRowMenuItem({ icon, title, color, disabled, onClick }: DataTableRowMenuItemProps) {
-  const { classes } = useStyles({ color });
   return (
-    <UnstyledButton className={classes.root} disabled={disabled} onClick={onClick}>
-      {icon && <Box className={classes.icon}>{icon}</Box>}
-      <Text className={classes.title} size="sm">
+    <UnstyledButton className={cx(classes.root)} style={{color: color}} disabled={disabled} onClick={onClick}>
+      {icon && <Box className={cx(classes.icon)}>{icon}</Box>}
+      <Text className={cx(classes.title)} size="sm">
         {title}
       </Text>
     </UnstyledButton>

--- a/package/DataTableRowSelectorCell.tsx
+++ b/package/DataTableRowSelectorCell.tsx
@@ -1,45 +1,40 @@
-import { Checkbox, createStyles, px } from '@mantine/core';
+import { Checkbox } from '@mantine/core';
 import type { ChangeEventHandler } from 'react';
+import classes from './styles/DataTableRowSelectorCell.css';
+import cx from 'clsx';
 
-const useStyles = createStyles((theme) => {
-  const shadowGradientAlpha = theme.colorScheme === 'dark' ? 0.5 : 0.05;
-  return {
-    root: {
-      position: 'sticky',
-      zIndex: 1,
-      width: 0,
-      left: 0,
-      background: 'inherit',
-      '&::after': {
-        content: '""',
-        position: 'absolute',
-        top: 0,
-        right: -px(theme.spacing.sm),
-        bottom: 0,
-        borderLeft: `1px solid ${theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]}`,
-        width: theme.spacing.sm,
-        background: `linear-gradient(to right, ${theme.fn.rgba(theme.black, shadowGradientAlpha)}, ${theme.fn.rgba(
-          theme.black,
-          0
-        )}), linear-gradient(to right, ${theme.fn.rgba(theme.black, shadowGradientAlpha)}, ${theme.fn.rgba(
-          theme.black,
-          0
-        )} 30%)`,
-        pointerEvents: 'none',
-        opacity: 0,
-        transition: 'opacity .15s ease',
-      },
+const shadowGradientAlpha = 'light-dark(0.05, 0.5)';
+const classes = {
+  root: {
+    position: 'sticky',
+    zIndex: 1,
+    width: 0,
+    left: 0,
+    background: 'inherit',
+    '&::after': {
+      content: '""',
+      position: 'absolute',
+      top: 0,
+      right: '-px(var(--mantine-spacing-sm))',
+      bottom: 0,
+      borderLeft: `1px solid light-dark(var(--mantine-color-dark-4), var(--mantine-color-gray-3))`,
+      width: 'var(--mantine-spacing-sm)',
+      background: `linear-gradient(to right, rgb(var(--mantine-color-black), ${shadowGradientAlpha})}, rgb(var(--mantine-color-black), 0)), 
+      linear-gradient(to right, rgb(var(--mantine-color-black), ${shadowGradientAlpha})}, rgb(var(--mantine-color-black), 30%))`,
+      pointerEvents: 'none',
+      opacity: 0,
+      transition: 'opacity .15s ease',
     },
-    withRightShadow: {
-      '&::after': {
-        opacity: 1,
-      },
+  },
+  withRightShadow: {
+    '&::after': {
+      opacity: 1,
     },
-    checkbox: {
-      cursor: 'pointer',
-    },
-  };
-});
+  },
+  checkbox: {
+    cursor: 'pointer',
+  },
+};
 
 type DataTableRowSelectorCellProps<T> = {
   record: T;
@@ -58,13 +53,12 @@ export default function DataTableRowSelectorCell<T>({
   getCheckboxProps,
   ...otherProps
 }: DataTableRowSelectorCellProps<T>) {
-  const { cx, classes } = useStyles();
   return (
     <td
-      className={cx(classes.root, { [classes.withRightShadow]: withRightShadow })}
+      className={cx(classes.root, withRightShadow ? classes.withRightShadow : null)}
       onClick={(e) => e.stopPropagation()}
     >
-      <Checkbox classNames={{ input: classes.checkbox }} {...otherProps} {...getCheckboxProps(record, recordIndex)} />
+      <Checkbox styles={{ input: {cursor: 'pointer'} }} {...otherProps} {...getCheckboxProps(record, recordIndex)} />
     </td>
   );
 }

--- a/package/DataTableRowSelectorCell.tsx
+++ b/package/DataTableRowSelectorCell.tsx
@@ -3,39 +3,6 @@ import type { ChangeEventHandler } from 'react';
 import classes from './styles/DataTableRowSelectorCell.css';
 import cx from 'clsx';
 
-const shadowGradientAlpha = 'light-dark(0.05, 0.5)';
-const classes = {
-  root: {
-    position: 'sticky',
-    zIndex: 1,
-    width: 0,
-    left: 0,
-    background: 'inherit',
-    '&::after': {
-      content: '""',
-      position: 'absolute',
-      top: 0,
-      right: '-px(var(--mantine-spacing-sm))',
-      bottom: 0,
-      borderLeft: `1px solid light-dark(var(--mantine-color-dark-4), var(--mantine-color-gray-3))`,
-      width: 'var(--mantine-spacing-sm)',
-      background: `linear-gradient(to right, rgb(var(--mantine-color-black), ${shadowGradientAlpha})}, rgb(var(--mantine-color-black), 0)), 
-      linear-gradient(to right, rgb(var(--mantine-color-black), ${shadowGradientAlpha})}, rgb(var(--mantine-color-black), 30%))`,
-      pointerEvents: 'none',
-      opacity: 0,
-      transition: 'opacity .15s ease',
-    },
-  },
-  withRightShadow: {
-    '&::after': {
-      opacity: 1,
-    },
-  },
-  checkbox: {
-    cursor: 'pointer',
-  },
-};
-
 type DataTableRowSelectorCellProps<T> = {
   record: T;
   recordIndex: number;

--- a/package/DataTableScrollArea.tsx
+++ b/package/DataTableScrollArea.tsx
@@ -1,79 +1,7 @@
-import { Box, createStyles, ScrollArea, ScrollAreaProps } from '@mantine/core';
+import { Box, ScrollArea, ScrollAreaProps } from '@mantine/core';
 import type { ReactNode, Ref } from 'react';
-
-const useStyles = createStyles((theme) => {
-  const shadowGradientAlpha = theme.colorScheme === 'dark' ? 0.5 : 0.05;
-  return {
-    root: {
-      flex: '1 1 100%',
-    },
-    scrollbar: {
-      '&[data-state="visible"]': { background: 'transparent' },
-      'div::before': { pointerEvents: 'none' },
-    },
-    corner: { background: 'transparent' },
-    thumb: {
-      zIndex: 3,
-    },
-    shadow: {
-      position: 'absolute',
-      pointerEvents: 'none',
-      opacity: 0,
-      transition: 'opacity .15s ease',
-    },
-    topShadow: {
-      zIndex: 2,
-      left: 0,
-      right: 0,
-      height: theme.spacing.sm,
-      background: `linear-gradient(${theme.fn.rgba(theme.black, shadowGradientAlpha)}, ${theme.fn.rgba(
-        theme.black,
-        0
-      )}), linear-gradient(${theme.fn.rgba(theme.black, shadowGradientAlpha)}, ${theme.fn.rgba(theme.black, 0)} 30%)`,
-    },
-    leftShadow: {
-      zIndex: 3,
-      top: 0,
-      left: 0,
-      bottom: 0,
-      width: theme.spacing.sm,
-      background: `linear-gradient(to right, ${theme.fn.rgba(theme.black, shadowGradientAlpha)}, ${theme.fn.rgba(
-        theme.black,
-        0
-      )}), linear-gradient(to right, ${theme.fn.rgba(theme.black, shadowGradientAlpha)}, ${theme.fn.rgba(
-        theme.black,
-        0
-      )} 30%)`,
-    },
-    rightShadow: {
-      zIndex: 2,
-      top: 0,
-      bottom: 0,
-      right: 0,
-      width: theme.spacing.sm,
-      background: `linear-gradient(to left, ${theme.fn.rgba(theme.black, shadowGradientAlpha)}, ${theme.fn.rgba(
-        theme.black,
-        0
-      )}), linear-gradient(to left, ${theme.fn.rgba(theme.black, shadowGradientAlpha)}, ${theme.fn.rgba(
-        theme.black,
-        0
-      )} 30%)`,
-    },
-    bottomShadow: {
-      zIndex: 2,
-      left: 0,
-      right: 0,
-      height: theme.spacing.sm,
-      background: `linear-gradient(${theme.fn.rgba(theme.black, 0)}, ${theme.fn.rgba(
-        theme.black,
-        shadowGradientAlpha
-      )}), linear-gradient(${theme.fn.rgba(theme.black, 0)} 30%, ${theme.fn.rgba(theme.black, shadowGradientAlpha)})`,
-    },
-    shadowVisible: {
-      opacity: 1,
-    },
-  };
-});
+import classes from './styles/DataTableScrollArea.css';
+import cx from 'clsx';
 
 type DataTableScrollAreaProps = {
   topShadowVisible: boolean;
@@ -101,25 +29,24 @@ export default function DataTableScrollArea({
   scrollAreaProps,
 }: DataTableScrollAreaProps) {
   const bottom = footerHeight ? footerHeight - 1 : 0;
-  const { cx, classes } = useStyles();
   return (
     <ScrollArea
       {...scrollAreaProps}
       viewportRef={viewportRef}
-      classNames={{ root: classes.root, scrollbar: classes.scrollbar, thumb: classes.thumb, corner: classes.corner }}
-      styles={{ scrollbar: { marginTop: headerHeight, marginBottom: bottom } }}
+      className={cx(classes.root, classes.scrollbar, classes.thumb, classes.corner)}
+      styles={{scrollbar: {marginTop: headerHeight, marginBottom: bottom }}}
       onScrollPositionChange={onScrollPositionChange}
     >
       {children}
       <Box
-        className={cx(classes.shadow, classes.topShadow, { [classes.shadowVisible]: topShadowVisible })}
-        sx={{ top: headerHeight }}
+        className={cx(classes.shadow, classes.topShadow)}
+        style={{ opacity: topShadowVisible ? classes.shadowVisible.opacity : '0', top: headerHeight }}
       />
-      <div className={cx(classes.shadow, classes.leftShadow, { [classes.shadowVisible]: leftShadowVisible })} />
-      <div className={cx(classes.shadow, classes.rightShadow, { [classes.shadowVisible]: rightShadowVisible })} />
+      <div style={{opacity: leftShadowVisible ? classes.shadowVisible.opacity : '0'}} className={cx(classes.shadow, classes.leftShadow)} />
+      <div style={{opacity: rightShadowVisible ? classes.shadowVisible.opacity : '0'}} className={cx(classes.shadow, classes.rightShadow)} />
       <Box
-        className={cx(classes.shadow, classes.bottomShadow, { [classes.shadowVisible]: bottomShadowVisible })}
-        sx={{ bottom }}
+        style={{opacity: bottomShadowVisible ? classes.shadowVisible.opacity : '0', bottom: bottom }}
+        className={cx(classes.shadow, classes.bottomShadow)}
       />
     </ScrollArea>
   );

--- a/package/package.json
+++ b/package/package.json
@@ -56,8 +56,8 @@
     "test:watch": "jest --watch"
   },
   "devDependencies": {
-    "@mantine/core": "^6.0.18",
-    "@mantine/hooks": "^6.0.18",
+    "@mantine/core": "^7.0.0",
+    "@mantine/hooks": "^7.0.0",
     "@tabler/icons-react": "^2.32.0",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
@@ -66,8 +66,8 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "@mantine/core": ">=6 <=6.0.17 || >=6.0.19",
-    "@mantine/hooks": ">=6 <=6.0.17 || >=6.0.19",
+    "@mantine/core": ">=7 <=7.0.0 || >=7.0.0",
+    "@mantine/hooks": ">=7 <=7.0.0 || >=7.0.0",
     "react": ">=18"
   }
 }

--- a/package/postcss.config.js
+++ b/package/postcss.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+    plugins: {
+        'postcss-preset-mantine': {},
+        'postcss-simple-vars': {
+            variables: {
+                'mantine-breakpoint-xs': '36em',
+                'mantine-breakpoint-sm': '48em',
+                'mantine-breakpoint-md': '62em',
+                'mantine-breakpoint-lg': '75em',
+                'mantine-breakpoint-xl': '88em',
+            },
+        },
+    },
+};

--- a/package/styles/DataTable.css
+++ b/package/styles/DataTable.css
@@ -1,0 +1,43 @@
+.root {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+  .root tr {
+    background-color: light-dark(var(--mantine-color-white, var(--mantine-color-dark-7)));
+  }
+  .root thead tr th {
+    border-bottom-color: rgb(light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4)));
+  }
+  .root tbody tr td {
+    border-top-color: rgb(light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4)));
+  }
+
+  .root.lastRowBorderBottomVisible tbody tr:last-of-type td {
+    border-bottom: 1px solid rgb(light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4) / 65%));
+  }
+
+  .textSelectionDisabled {
+    user-select: none;
+  }
+  .table {
+    border-collapse: separate;
+    border-spacing: 0;
+  }
+  .tableWithBorder {
+    border: 1px solid rgb(light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4)));
+  }
+  .tableWithColumnBorders th:not(:first-of-type),
+  .tableWithColumnBorders td:not(:first-of-type) {
+    border-left: 1px solid rgb(light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4) / 65%));
+  }
+  .tableWithColumnBordersAndSelectableRecords thead tr + tr th {
+    border-left: 1px solid rgb(light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4) / 65%));
+  }
+  .verticalAlignmentTop td {
+    vertical-align: top;
+  }
+  .verticalAlignmentBottom td {
+    vertical-align: bottom;
+  }

--- a/package/styles/DataTableEmptyRow.css
+++ b/package/styles/DataTableEmptyRow.css
@@ -1,0 +1,9 @@
+
+  .root {
+    && {
+      background: transparent;
+      &:last-of-type td {
+        border-bottom: none;
+      }
+    }
+  }

--- a/package/styles/DataTableEmptyState.css
+++ b/package/styles/DataTableEmptyState.css
@@ -1,0 +1,24 @@
+
+  .root {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    flex-direction: column;
+    pointer-events: none;
+    color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-dark-3));
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+
+  .active {
+    opacity: 1;
+  }
+
+  .standardIcon {
+    font-size: 0;
+    border-radius: 50%;
+    padding: var(--spacing-xs);
+    background: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
+  }

--- a/package/styles/DataTableFooter.css
+++ b/package/styles/DataTableFooter.css
@@ -1,0 +1,10 @@
+
+
+  .root {
+    z-index: 2;
+    background: light-dark(var(--mantine-color-white), var(--mantine-color-dark-7));
+  }
+
+  .textSelectionDisabled {
+    user-select: none;
+  }

--- a/package/styles/DataTableFooterCell.css
+++ b/package/styles/DataTableFooterCell.css
@@ -1,0 +1,8 @@
+noWrap {
+    whiteSpace: 'nowrap';
+  }
+
+  ellipsis {
+    overflow: 'hidden';
+    textOverflow: 'ellipsis';
+  }

--- a/package/styles/DataTableFooterSelectorPlaceholderCell.css
+++ b/package/styles/DataTableFooterSelectorPlaceholderCell.css
@@ -1,0 +1,27 @@
+
+.root {
+    position: sticky;
+    width: 0;
+    left: 0;
+    background: inherit;
+  }
+  
+  .root::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: -var(--mantine-spacing-sm);
+    bottom: 0;
+    border-left: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4)));
+    width: var(--mantine-spacing-sm);
+    background: linear-gradient(to right, rgba(var(--mantine-color-black) / light-dark(0.05, 0.5)), rgba(var(--mantine-color-black) / 0)), linear-gradient(to right, rgba(var(--mantine-color-black) / light-dark(0.05, 0.5)), rgba(var(--mantine-color-black) / 0) 30%);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+  
+  .shadowVisible::after {
+    opacity: 1;
+  }
+
+  

--- a/package/styles/DataTableHeader.css
+++ b/package/styles/DataTableHeader.css
@@ -1,0 +1,11 @@
+
+  .root {
+    z-index: 2;
+    position: sticky;
+    top: 0;
+    background: light-dark(var(--mantine-color-dark-7), var(--mantine-color-white));
+  }
+
+  .textSelectionDisabled {
+    user-select: none;
+  }

--- a/package/styles/DataTableHeaderCell.css
+++ b/package/styles/DataTableHeaderCell.css
@@ -1,0 +1,32 @@
+  .sortableColumnHeader {
+    cursor: pointer;
+    transition: background .15s ease;
+    &:hover:not(:has(button:hover)) {
+      background: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6));
+    }
+  }
+  .sortableColumnHeaderGroup {
+    gap: 0.25em;
+  }
+  .columnHeaderText {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+  .sortableColumnHeaderText {
+    min-width: 0;
+    flex-grow: 1;
+  }
+  .sortableColumnHeaderIcon {
+    transition: transform .15s ease;
+  }
+  .sortableColumnHeaderIconRotated {
+    transform: rotate3d(0, 0, 1, 180deg);
+  }
+  .sortableColumnHeaderUnsortedIcon {
+    color: light-dark(var(--mantine-color-dark-5), var(--mantine-color-gray-3));
+    transition: color .15s ease;
+    th:hover & {
+      color: light-dark(var(--mantine-color-dark-6), var(--mantine-color-gray-2));
+    }
+  }

--- a/package/styles/DataTableHeaderSelectorCell.css
+++ b/package/styles/DataTableHeaderSelectorCell.css
@@ -1,0 +1,33 @@
+:root {
+    --shadow-gradient-alpha: 0.05;
+  }
+  
+  .root {
+    position: sticky;
+    width: 0;
+    left: 0;
+    background: inherit;
+  }
+  
+  .root::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: var(--mantine-spacing-sm);
+    bottom: 0;
+    border-left: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+    width: var(--mantine-spacing-sm);
+    background: linear-gradient(to right, rgba(var(--mantine-color-black) / light-dark(0.05, 0.5)), rgba(var(--mantine-color-black) / 0)), linear-gradient(to right, rgba(var(--mantine-color-black), / light-dark(0.05, 0.5)), rgba(var(--mantine-color-black) / 0) 30%);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+  
+  .shadowVisible::after {
+    opacity: 1;
+  }
+  
+  .checkboxInput {
+    cursor: pointer;
+  }
+  

--- a/package/styles/DataTableHeaderSelectorCell.css
+++ b/package/styles/DataTableHeaderSelectorCell.css
@@ -1,7 +1,3 @@
-:root {
-    --shadow-gradient-alpha: 0.05;
-  }
-  
   .root {
     position: sticky;
     width: 0;

--- a/package/styles/DataTableLoader.css
+++ b/package/styles/DataTableLoader.css
@@ -1,0 +1,17 @@
+  .root {
+    z-index: 3;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    pointer-events: none;
+    background: rgb(light-dark(var(--mantine-color-white), var(--mantine-color-dark-8)) / 75%);
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+
+  .fetching {
+    pointer-events: all;
+    opacity: 1;
+  }

--- a/package/styles/DataTablePagination.css
+++ b/package/styles/DataTablePagination.css
@@ -1,0 +1,27 @@
+.root {
+  background: var(--colorScheme-dark-7, #1c1c1c);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-xs);
+}
+
+@media (min-width: var(--mantine-breakpoint-sm)) {
+  .root {
+    flex-direction: row;
+  }
+}
+
+.text {
+  flex: 1 1 auto;
+}
+
+.pagination {
+  opacity: 1;
+  transition: opacity 0.15s ease;
+}
+
+.paginationFetching {
+  opacity: 0;
+}

--- a/package/styles/DataTablePagination.css
+++ b/package/styles/DataTablePagination.css
@@ -1,10 +1,10 @@
 .root {
-  background: var(--colorScheme-dark-7, #1c1c1c);
+  background: light-dark(var(--mantine-color-white), var(--mantine-color-dark-7));
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
-  gap: var(--spacing-xs);
+  gap: var(--mantine-spacing-xs);
 }
 
 @media (min-width: var(--mantine-breakpoint-sm)) {

--- a/package/styles/DataTableRow.css
+++ b/package/styles/DataTableRow.css
@@ -1,0 +1,25 @@
+withPointerCursor {
+    cursor: 'pointer';
+}
+
+selected {
+  && {
+    tr& {
+      background: light-dark(rgb(var(--mantine-color-primary-6) / 90%), rgb(var(--mantine-color-primary-6) / 60%));
+    }
+    table[data-striped] tbody &:nth-of-type(odd) {
+        background: light-dark(rgb(var(--mantine-color-primary-6) / 85%), rgb(var(--mantine-color-primary-6) / 55%));
+    }
+  }
+}
+
+contextMenuVisible {
+  && {
+    tr& {
+      background: light-dark(rgb(var(--mantine-color-primary-6) / 70%), rgb(var(--mantine-color-primary-6) / 50%));
+    }
+    table[data-striped] tbody &:nth-of-type(odd) {
+        background: light-dark(rgb(var(--mantine-color-primary-6) / 65%), rgb(var(--mantine-color-primary-6) / 45%));
+    }
+  }
+}

--- a/package/styles/DataTableRowCell.css
+++ b/package/styles/DataTableRowCell.css
@@ -1,0 +1,10 @@
+.withPointerCursor {
+  cursor: pointer;
+}
+.noWrap {
+  white-space: nowrap;
+}
+.ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/package/styles/DataTableRowExpansion.css
+++ b/package/styles/DataTableRowExpansion.css
@@ -1,0 +1,11 @@
+cell {
+  &&: {
+    borderBottomWidth: 0;
+    padding: 0;
+  }
+}
+expandedCell {
+  &&: {
+    borderBottomWidth: 1;
+  }
+}

--- a/package/styles/DataTableRowExpansion.css
+++ b/package/styles/DataTableRowExpansion.css
@@ -1,11 +1,11 @@
 cell {
-  &&: {
+  && {
     borderBottomWidth: 0;
     padding: 0;
   }
 }
 expandedCell {
-  &&: {
+  && {
     borderBottomWidth: 1;
   }
 }

--- a/package/styles/DataTableRowMenu.css
+++ b/package/styles/DataTableRowMenu.css
@@ -1,6 +1,6 @@
-root: {
-    position: fixed,
-    border: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4)),
-    overflow: hidden,
-    transition: all .15s ease,
+root {
+    position: fixed;
+    border: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+    overflow: hidden;
+    transition: all .15s ease;
 }

--- a/package/styles/DataTableRowMenu.css
+++ b/package/styles/DataTableRowMenu.css
@@ -1,0 +1,6 @@
+root: {
+    position: fixed,
+    border: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4)),
+    overflow: hidden,
+    transition: all .15s ease,
+}

--- a/package/styles/DataTableRowMenuDivider.css
+++ b/package/styles/DataTableRowMenuDivider.css
@@ -1,0 +1,4 @@
+root {
+    height: 1,
+    background: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5));
+}

--- a/package/styles/DataTableRowMenuDivider.css
+++ b/package/styles/DataTableRowMenuDivider.css
@@ -1,4 +1,4 @@
 root {
-    height: 1,
+    height: 1;
     background: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5));
 }

--- a/package/styles/DataTableRowMenuItem.css
+++ b/package/styles/DataTableRowMenuItem.css
@@ -1,0 +1,28 @@
+.root {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    padding-top: calc(var(--mantine-spacing-sm) / 2);
+    padding-bottom: calc(var(--mantine-spacing-sm) / 2);
+    padding-left: var(--mantine-spacing-sm);
+    padding-right: var(--mantine-spacing-sm);
+    transition: background 0.15s ease;
+    & [disabled] {
+      cursor: not-allowed;
+      color: var(--color-dark-3);
+    }
+    &:hover:not([disabled]) {
+      background: rgba(var(--color-gray-4), 0.25);
+    }
+    &:active:not([disabled]) {
+      background: rgba(var(--color-gray-4), 0.5);
+    }
+  }
+  .icon {
+    font-size: 0;
+    margin-right: var(--spacing-xs);
+  }
+  .title {
+    white-space: nowrap;
+  }
+  

--- a/package/styles/DataTableRowSelectorCell.css
+++ b/package/styles/DataTableRowSelectorCell.css
@@ -1,0 +1,31 @@
+.root {
+    position: sticky;
+    z-index: 1;
+    width: 0;
+    left: 0;
+    background: inherit;
+  }
+
+  .root::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: -px(var(--mantine-spacing-sm));
+    bottom: 0;
+    border-left: 1px solid light-dark(var(--mantine-color-dark-4), var(--mantine-color-gray-3));
+    width: var(--mantine-spacing-sm);
+    background: linear-gradient(to right, rgb(var(--mantine-color-black), light-dark(0.05, 0.5))), linear-gradient(to right, rgb(var(--mantine-color-black), light-dark(0.05, 0.5) 30%));
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity .15s ease;
+  }
+
+  .withRightShadow {
+    &::after {
+        opacity: 1;
+    }
+  }
+
+  .checkbox {
+    cursor: pointer;
+  }

--- a/package/styles/DataTableScrollArea.css
+++ b/package/styles/DataTableScrollArea.css
@@ -2,9 +2,9 @@
     flex: 1 1 100%;
 }
 
-scrollbar: {
-    &[data-state="visible"]: { background: 'transparent' },
-    div::before: { pointerEvents: 'none' },
+scrollbar {
+    &[data-state="visible"]: { background: 'transparent' };
+    div::before: { pointerEvents: 'none' };
 }
 
 .corner {
@@ -27,7 +27,7 @@ scrollbar: {
     left: 0;
     right: 0;
     height: var(--mantine-spacing-sm);
-    background: linear-gradient(rgb(var(--mantine-color-black), light-dark(0.05, 0.5)), rgb(var(--mantine-color-black), 0)),
+    background: linear-gradient(rgb(var(--mantine-color-black), light-dark(0.05, 0.5)), rgb(var(--mantine-color-black), 0));
         linear-gradient(rgb(var(--mantine-color-black), light-dark(0.05, 0.5)), rgb(var(--mantine-color-black), 0) 30%);
 }
 
@@ -37,7 +37,7 @@ scrollbar: {
     left: 0;
     bottom: 0;
     width: var(--mantine-spacing-sm);
-    background: linear-gradient(to right, rgb(var(--mantine-color-black), light-dark(0.05, 0.5)), rgb(var(--mantine-color-black), 0)),
+    background: linear-gradient(to right, rgb(var(--mantine-color-black), light-dark(0.05, 0.5)), rgb(var(--mantine-color-black), 0));
         linear-gradient(to right, rgb(var(--mantine-color-black), light-dark(0.05, 0.5)), rgb(var(--mantine-color-black), 0.3));
 }
 
@@ -47,7 +47,7 @@ scrollbar: {
     bottom: 0;
     right: 0;
     width: var(--mantine-spacing-sm);
-    background: linear-gradient(to right, rgb(var(--mantine-color-black), light-dark(0.05, 0.5)), rgb(var(--mantine-color-black), 0)),
+    background: linear-gradient(to right, rgb(var(--mantine-color-black), light-dark(0.05, 0.5)), rgb(var(--mantine-color-black), 0));
         linear-gradient(to right, rgb(var(--mantine-color-black), light-dark(0.05, 0.5)), rgb(var(--mantine-color-black), 0.3));
 }
 
@@ -56,7 +56,7 @@ scrollbar: {
     left: 0;
     right: 0;
     height: var(--mantine-spacing-sm);
-    background: linear-gradient(rgb(var(--mantine-color-black), 0), rgb(var(--mantine-color-black), light-dark(0.05, 0.5))),
+    background: linear-gradient(rgb(var(--mantine-color-black), 0), rgb(var(--mantine-color-black), light-dark(0.05, 0.5)));
         linear-gradient(rgb(var(--mantine-color-black), 0) 30%, rgb(var(--mantine-color-black), light-dark(0.05, 0.5)));
 }
 

--- a/package/styles/DataTableScrollArea.css
+++ b/package/styles/DataTableScrollArea.css
@@ -1,0 +1,65 @@
+.root {
+    flex: 1 1 100%;
+}
+
+scrollbar: {
+    &[data-state="visible"]: { background: 'transparent' },
+    div::before: { pointerEvents: 'none' },
+}
+
+.corner {
+    background: transparent;
+}
+
+.thumb {
+    z-index: 3;
+}
+
+.shadow {
+    position: absolute;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity .15s ease;
+}
+
+.topShadow {
+    z-index: 2;
+    left: 0;
+    right: 0;
+    height: var(--mantine-spacing-sm);
+    background: linear-gradient(rgb(var(--mantine-color-black), light-dark(0.05, 0.5)), rgb(var(--mantine-color-black), 0)),
+        linear-gradient(rgb(var(--mantine-color-black), light-dark(0.05, 0.5)), rgb(var(--mantine-color-black), 0) 30%);
+}
+
+.leftShadow {
+    z-index: 3;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: var(--mantine-spacing-sm);
+    background: linear-gradient(to right, rgb(var(--mantine-color-black), light-dark(0.05, 0.5)), rgb(var(--mantine-color-black), 0)),
+        linear-gradient(to right, rgb(var(--mantine-color-black), light-dark(0.05, 0.5)), rgb(var(--mantine-color-black), 0.3));
+}
+
+.rightShadow {
+    z-index: 2;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    width: var(--mantine-spacing-sm);
+    background: linear-gradient(to right, rgb(var(--mantine-color-black), light-dark(0.05, 0.5)), rgb(var(--mantine-color-black), 0)),
+        linear-gradient(to right, rgb(var(--mantine-color-black), light-dark(0.05, 0.5)), rgb(var(--mantine-color-black), 0.3));
+}
+
+.bottomShadow {
+    z-index: 2;
+    left: 0;
+    right: 0;
+    height: var(--mantine-spacing-sm);
+    background: linear-gradient(rgb(var(--mantine-color-black), 0), rgb(var(--mantine-color-black), light-dark(0.05, 0.5))),
+        linear-gradient(rgb(var(--mantine-color-black), 0) 30%, rgb(var(--mantine-color-black), light-dark(0.05, 0.5)));
+}
+
+.shadowVisible {
+    opacity: 1;
+}

--- a/package/types/DataTableColumn.ts
+++ b/package/types/DataTableColumn.ts
@@ -90,11 +90,6 @@ export type DataTableColumn<T> = {
   titleStyle?: CSSProperties;
 
   /**
-   * Optional style passed to the column title; see https://mantine.dev/styles/sx/
-   */
-  titleSx?: Sx;
-
-  /**
    * Optional class name passed to each data cell in the column; can be a string or a function
    * receiving the current record and its index as arguments and returning a string
    */
@@ -105,11 +100,6 @@ export type DataTableColumn<T> = {
    * a function receiving the current record and its index as arguments and returning a CSS properties object
    */
   cellsStyle?: CSSProperties | ((record: T, recordIndex: number) => CSSProperties | undefined);
-
-  /**
-   * Optional style passed to each data cell in the column; see https://mantine.dev/styles/sx/
-   */
-  cellsSx?: Sx;
 
   /**
    * Optional function returning an object of custom attributes to be applied to each cell in the column.
@@ -133,12 +123,8 @@ export type DataTableColumn<T> = {
    */
   footerStyle?: CSSProperties;
 
-  /**
-   * Optional style passed to the column footer; see https://mantine.dev/styles/sx/
-   */
-  footerSx?: Sx;
 } & (
-  | {
+    | {
       /**
        * If true, cell content in this column will be truncated with ellipsis as needed and will not wrap
        * to multiple lines.
@@ -149,7 +135,7 @@ export type DataTableColumn<T> = {
 
       noWrap?: never;
     }
-  | {
+    | {
       ellipsis?: never;
 
       /**
@@ -159,4 +145,4 @@ export type DataTableColumn<T> = {
        */
       noWrap?: boolean;
     }
-);
+  );

--- a/package/types/DataTableColumnGroup.ts
+++ b/package/types/DataTableColumnGroup.ts
@@ -1,4 +1,3 @@
-import type { Sx } from '@mantine/core';
 import type { CSSProperties, ReactNode } from 'react';
 import type { DataTableColumn } from './DataTableColumn';
 
@@ -16,6 +15,5 @@ export type DataTableColumnGroup<T> = {
    */
   columns: readonly DataTableColumn<T>[];
   className?: string;
-  sx?: Sx;
   style?: CSSProperties;
 };

--- a/package/types/DataTableProps.ts
+++ b/package/types/DataTableProps.ts
@@ -1,4 +1,4 @@
-import type { DefaultProps, MantineShadow, MantineTheme, ScrollAreaProps, Sx, TableProps } from '@mantine/core';
+import type { MantineColorScheme, MantineShadow, ScrollAreaProps, TableProps } from '@mantine/core';
 import type { CSSProperties, Key, MouseEvent, ReactNode, RefObject } from 'react';
 import type {
   DataTableCellClickHandler,
@@ -41,13 +41,13 @@ export type DataTableProps<T> = {
    * footer top border; defaults to
    * `(theme) => (theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3])`
    */
-  borderColor?: string | ((theme: MantineTheme) => string);
+  borderColor?: string | ((theme: MantineColorScheme) => string);
 
   /**
    * Row border color; defaults to
    * `(theme) => (theme.fn.rgba(theme.colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3], 0.65))`
    */
-  rowBorderColor?: string | ((theme: MantineTheme) => string);
+  rowBorderColor?: string | ((theme: MantineColorScheme) => string);
 
   /**
    * If true, the user will not be able to select text
@@ -150,11 +150,6 @@ export type DataTableProps<T> = {
    * a function receiving the current record and its index as arguments and returning a CSS properties object
    */
   rowStyle?: CSSProperties | ((record: T, recordIndex: number) => CSSProperties | undefined);
-
-  /**
-   * Optional style passed to each row; see https://mantine.dev/styles/sx/
-   */
-  rowSx?: Sx;
 
   /**
    * Optional function returning an object of custom attributes to be applied to each row in the table.


### PR DESCRIPTION
This is my first pass at updating to Mantine 7.0.0. There was a lot of obvious ways to convert the `useStyles` to a css file. There were also non-obvious conversions, especially props that were expecting the theme.  I also did not go over any of the typing files used for documentation. 


My intention with this PR is not to have the completed conversion, but rather provide much of the leg work for copy, pasting, and formatting and letting the primary maintainer or someone else with more knowledge/time finish it. 