### PR TITLE
docs: Set `Nested popovers` for Select to display correctly inside the Filter

### DIFF
--- a/app/examples/searching-and-filtering/SearchingAndFilteringExample.tsx
+++ b/app/examples/searching-and-filtering/SearchingAndFilteringExample.tsx
@@ -90,6 +90,7 @@ export function SearchingAndFilteringExample() {
               placeholder="Search departments…"
               onChange={setSelectedDepartments}
               leftSection={<IconSearch size={16} />}
+              comboboxProps={{ withinPortal: false }}
               clearable
               searchable
             />


### PR DESCRIPTION
issue #595

Since this package uses `Popover` components within the filter, any Mantine components rendered inside must not use portals to avoid display issues.

To address this, I added the option `comboboxProps={{ withinPortal: false }}` to the `MultiSelect` component.

details:
https://mantine.dev/core/popover/#nested-popovers