### PR TITLE
Prevent Sorting from Being Triggered When Using Filter Popovers with Keyboard Input

### DIFF
--- a/package/DataTableHeaderCellFilter.tsx
+++ b/package/DataTableHeaderCellFilter.tsx
@@ -25,11 +25,19 @@ export function DataTableHeaderCellFilter<T>({ children, isActive }: DataTableHe
             e.preventDefault();
             toggle();
           }}
+          onKeyDown={(e) => {
+            e.stopPropagation();
+          }}
         >
           <Icon />
         </ActionIcon>
       </PopoverTarget>
-      <PopoverDropdown onClick={(e) => e.stopPropagation()}>
+      <PopoverDropdown
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          e.stopPropagation();
+        }}
+      >
         {typeof children === 'function' ? children({ close }) : children}
       </PopoverDropdown>
     </Popover>


### PR DESCRIPTION
When using both sorting and filtering, the following issues occur when navigating with the keyboard:

- Pressing Enter while focusing on the filter icon not only opens the popover but also triggers sorting.
- Pressing Enter inside the input field within the popover also causes sorting to be triggered.

To prevent these issues, we stop the propagation of keydown events on the filter icon and within the PopoverDropdown.