### PR TITLE
Add prop to disable datatable filter cell popover useClickOutside

### DIFF
--- a/package/DataTableHeader.tsx
+++ b/package/DataTableHeader.tsx
@@ -130,6 +130,7 @@ export const DataTableHeader = forwardRef(function DataTableHeader<T>(
             titleStyle,
             filter,
             filterPopoverProps,
+            filterPopoverDisableClickOutside,
             filtering,
             sortKey,
           } = { ...defaultColumnProps, ...columnProps };
@@ -155,6 +156,7 @@ export const DataTableHeader = forwardRef(function DataTableHeader<T>(
               onSortStatusChange={onSortStatusChange}
               filter={filter}
               filterPopoverProps={filterPopoverProps}
+              filterPopoverDisableClickOutside={filterPopoverDisableClickOutside}
               filtering={filtering}
             />
           );

--- a/package/DataTableHeaderCell.tsx
+++ b/package/DataTableHeaderCell.tsx
@@ -32,6 +32,7 @@ type DataTableHeaderCellProps<T> = {
   | 'width'
   | 'filter'
   | 'filterPopoverProps'
+  | 'filterPopoverDisableClickOutside'
   | 'filtering'
   | 'sortKey'
 >;
@@ -53,6 +54,7 @@ export function DataTableHeaderCell<T>({
   onSortStatusChange,
   filter,
   filterPopoverProps,
+  filterPopoverDisableClickOutside,
   filtering,
   sortKey,
 }: DataTableHeaderCellProps<T>) {
@@ -220,7 +222,7 @@ export function DataTableHeaderCell<T>({
           </>
         ) : null}
         {filter ? (
-          <DataTableHeaderCellFilter filterPopoverProps={filterPopoverProps} isActive={!!filtering}>
+          <DataTableHeaderCellFilter filterPopoverProps={filterPopoverProps} isActive={!!filtering} filterPopoverDisableClickOutside={filterPopoverDisableClickOutside}>
             {filter}
           </DataTableHeaderCellFilter>
         ) : null}

--- a/package/DataTableHeaderCellFilter.tsx
+++ b/package/DataTableHeaderCellFilter.tsx
@@ -7,6 +7,7 @@ import type { DataTableColumn } from './types';
 type DataTableHeaderCellFilterProps<T> = {
   children: DataTableColumn<T>['filter'];
   filterPopoverProps: DataTableColumn<T>['filterPopoverProps'];
+  filterPopoverDisableClickOutside?: DataTableColumn<T>['filterPopoverDisableClickOutside'];
   isActive: boolean;
 };
 
@@ -14,10 +15,11 @@ export function DataTableHeaderCellFilter<T>({
   children,
   isActive,
   filterPopoverProps,
+  filterPopoverDisableClickOutside,
 }: DataTableHeaderCellFilterProps<T>) {
   const [isOpen, { close, toggle }] = useDisclosure(false);
   const Icon = isActive ? IconFilterFilled : IconFilter;
-  const ref = useClickOutside(close);
+  const ref = filterPopoverDisableClickOutside ? undefined : useClickOutside(close);
 
   return (
     <Popover withArrow shadow="md" opened={isOpen} onClose={close} trapFocus {...filterPopoverProps}>

--- a/package/types/DataTableColumn.ts
+++ b/package/types/DataTableColumn.ts
@@ -89,6 +89,11 @@ export type DataTableColumn<T = Record<string, unknown>> = {
   filterPopoverProps?: PopoverProps;
 
   /**
+   * Disables the use of the Mantine useClickOutside hook inside the filter popover
+   */
+  filterPopoverDisableClickOutside?: boolean;
+
+  /**
    * If true, filter icon will be styled differently to indicate the filter is in effect.
    */
   filtering?: boolean;


### PR DESCRIPTION
**Reason:**
The fix for #659 has broken filter popovers for applications that use the datatable inside the shadow DOM with webcomponents.

This is because the useClickOutside hook doesn't get the events propagated from the shadow DOM. This makes it so when we click any part of a control inside the popover, it will close the popover.

**Suggested Fix:**
I just added a prop that lets us disable this behavior. Some other ideas were to let the user pass in a custom Popover component for complete control.

What do you think?

@icflorescu 
































































































































































































