### PR TITLE
Implement basic functionality for virtualization

### DIFF
--- a/app/config.ts
+++ b/app/config.ts
@@ -258,6 +258,11 @@ export const ROUTES: RouteInfo[] = [
     description: `Example: a complex usage scenario for ${PRODUCT_NAME} featuring custom column definitions, asynchronous data loading with React Query, sorting, pagination, custom cell rendering, multiple row selection, and more`,
   },
   {
+    href: '/examples/virtualization',
+    title: 'Virtualization',
+    description: `Example: how to enable virtualization on ${PRODUCT_NAME}`,
+  },
+  {
     href: '/type-definitions',
     title: 'Type definitions',
     description: `${PRODUCT_NAME} is written in TypeScript and its options are well documented with additional JSDoc annotations`,

--- a/app/examples/virtualization/VirtualizationExample.module.css
+++ b/app/examples/virtualization/VirtualizationExample.module.css
@@ -1,0 +1,26 @@
+.buttons {
+  width: 100%;
+  display: flex;
+  gap: var(--mantine-spacing-md);
+  flex-direction: column;
+  @media (min-width: rem(400px)) {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+}
+
+.button {
+  width: 100%;
+  @media (min-width: rem(400px)) {
+    width: calc(50% - (var(--mantine-spacing-md) / 2));
+  }
+  @media (min-width: rem(660px)) {
+    width: calc((100% - var(--mantine-spacing-md) * 3) / 4);
+  }
+  @media (min-width: $mantine-breakpoint-sm) {
+    width: calc(50% - (var(--mantine-spacing-md) / 2));
+  }
+  @media (min-width: $mantine-breakpoint-md) {
+    width: calc((100% - var(--mantine-spacing-md) * 3) / 4);
+  }
+}

--- a/app/examples/virtualization/VirtualizationExample.tsx
+++ b/app/examples/virtualization/VirtualizationExample.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { faker } from '@faker-js/faker';
+import { Button, Center, Paper } from '@mantine/core';
+import { DataTable } from '__PACKAGE__';
+import { useState } from 'react';
+import classes from './VirtualizationExample.module.css';
+
+type User = {
+  id: string;
+  name: string;
+  age: number;
+};
+
+const userData: User[] = Array.from({ length: 2000 }, () => ({
+  id: faker.string.uuid(),
+  name: faker.person.fullName(),
+  age: faker.number.int({ min: 18, max: 65 }),
+}));
+
+export function VirtualizationExample() {
+  const [virtualized, setVirtualized] = useState(false);
+
+  const toggleVirtualized = () => setVirtualized((current) => !current);
+
+  // example-start
+  // ...
+
+  return (
+    <>
+      <DataTable
+        virtualize={virtualized}
+        borderRadius="sm"
+        withTableBorder
+        minHeight={200}
+        columns={[{ accessor: 'id' }, { accessor: 'name' }, { accessor: 'age' }]}
+        records={userData}
+        height={400}
+        rowExpansion={{
+          content: ({ record }) => (
+            <div style={{ padding: 10 }}>
+              <div>ID: {record.id}</div>
+              <div>Name: {record.name}</div>
+              <div>Age: {record.age}</div>
+            </div>
+          ),
+        }}
+      />
+      {/* example-skip */}
+      <Paper p="md" mt="sm" withBorder>
+        <Center>
+          <div className={classes.buttons}>
+            <Button className={classes.button} color="green" onClick={toggleVirtualized}>
+              {virtualized ? 'Disable' : 'Enable'} virtualization
+            </Button>
+          </div>
+        </Center>
+      </Paper>
+      {/* example-resume */}
+    </>
+  );
+  // example-end
+}

--- a/app/examples/virtualization/page.tsx
+++ b/app/examples/virtualization/page.tsx
@@ -1,0 +1,35 @@
+import { Code } from '@mantine/core';
+import type { Route } from 'next';
+import { CodeBlock } from '~/components/CodeBlock';
+import { ExternalLink } from '~/components/ExternalLink';
+import { PageNavigation } from '~/components/PageNavigation';
+import { PageTitle } from '~/components/PageTitle';
+import { Txt } from '~/components/Txt';
+import { readCodeFile } from '~/lib/code';
+import { getRouteMetadata } from '~/lib/utils';
+import { VirtualizationExample } from './VirtualizationExample';
+
+const PATH: Route = '/examples/virtualization';
+
+export const metadata = getRouteMetadata(PATH);
+
+export default async function VirtualizationExamplePage() {
+  const code = await readCodeFile<string>(`${PATH}/VirtualizationExample.tsx`);
+
+  return (
+    <>
+      <PageTitle of={PATH} />
+      <Txt>
+        The <Code>DataTable</Code> component exposes a <Code>bodyRef</Code> property that can be used to pass a ref to
+        the underlying table <Code>tbody</Code> element. This ref can be passed to the <Code>useAutoAnimate()</Code>{' '}
+        hook from the excellent <ExternalLink to="https://auto-animate.formkit.com/">AutoAnimate</ExternalLink> library
+        to animate table rows when they are added, removed or reordered.
+      </Txt>
+      <VirtualizationExample />
+      <Txt>Here is the code:</Txt>
+      <CodeBlock code={code} />
+      <Txt>Head over to the next example to learn more.</Txt>
+      <PageNavigation of={PATH} />
+    </>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -116,5 +116,8 @@
     "@mantine/hooks": ">=7.14",
     "clsx": ">=2",
     "react": ">=18.2"
+  },
+  "dependencies": {
+    "@tanstack/react-virtual": "^3.10.8"
   }
 }

--- a/package/DataTableRow.tsx
+++ b/package/DataTableRow.tsx
@@ -50,6 +50,7 @@ type DataTableRowProps<T> = {
   selectionColumnClassName: string | undefined;
   selectionColumnStyle: MantineStyleProp | undefined;
   idAccessor: string;
+  rowRef: React.Ref<HTMLTableRowElement>;
 } & Pick<DataTableProps<T>, 'rowFactory'>;
 
 export function DataTableRow<T>({
@@ -81,6 +82,7 @@ export function DataTableRow<T>({
   selectionColumnClassName,
   selectionColumnStyle,
   rowFactory,
+  rowRef,
 }: Readonly<DataTableRowProps<T>>) {
   const cols = (
     <>
@@ -189,7 +191,9 @@ export function DataTableRow<T>({
 
   return (
     <>
-      <TableTr {...rowProps}>{cols}</TableTr>
+      <TableTr ref={rowRef} data-index={index} {...rowProps}>
+        {cols}
+      </TableTr>
       {expandedElement}
     </>
   );

--- a/package/types/DataTableProps.ts
+++ b/package/types/DataTableProps.ts
@@ -250,6 +250,12 @@ export type DataTableProps<T = Record<string, unknown>> = {
    * Ref pointing to the table body element.
    */
   bodyRef?: ((instance: HTMLTableSectionElement | null) => void) | React.RefObject<HTMLTableSectionElement>;
+
+  /**
+   * Determines whether the table should be virtualized. Note that virtualization is not compatible with
+   * using a tableWrapper function.
+   */
+  virtualize?: boolean;
 } & Omit<
   TableProps,
   | 'onScroll'

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,6 +835,18 @@
   dependencies:
     "@tanstack/query-core" "5.62.8"
 
+"@tanstack/react-virtual@^3.10.8":
+  version "3.10.8"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.10.8.tgz#bf4b06f157ed298644a96ab7efc1a2b01ab36e3c"
+  integrity sha512-VbzbVGSsZlQktyLrP5nxE+vE1ZR+U0NFAWPbJLoG2+DKPwd2D7dVICTVIIaYlJqX1ZCEnYDbaOpmMwbsyhBoIA==
+  dependencies:
+    "@tanstack/virtual-core" "3.10.8"
+
+"@tanstack/virtual-core@3.10.8":
+  version "3.10.8"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.10.8.tgz#975446a667755222f62884c19e5c3c66d959b8b4"
+  integrity sha512-PBu00mtt95jbKFi6Llk9aik8bnR3tR/oQP1o3TSi+iG//+Q2RTIzCEgKkHG8BB86kxMNW6O8wku+Lmi+QFR6jA==
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"


### PR DESCRIPTION
Hi @icflorescu !

Recently the need for a virtualization increased on my side. I tried to implement the virtualization with TanStack's [virtual table example](https://tanstack.com/virtual/latest/docs/framework/react/examples/table).
So far the base implementation (measuring elements, overscanning, remounting DOM elements, ...) works.

What is left:
- Fix remaining (visual) dependencies which might interfere with the positioning mechanism
- - e.g. Sticky header and footer, row expansion, drag and drop, ...
- Adapt the boilerplate example page I created

I hope you or someone else can support with the relative visual todos so that we can all benefit from the feature.