### PR TITLE
BUGFIX: Selection header column is shows behind other header columns when scrolling with resize

### DIFF
--- a/app/examples/column-resizing/ResizingComplexExample.tsx
+++ b/app/examples/column-resizing/ResizingComplexExample.tsx
@@ -14,6 +14,7 @@ export default function ResizingComplexExample() {
     direction: 'asc',
   });
   const [records, setRecords] = useState(sortBy(companies, 'name'));
+  const [selectedRecords, setSelectedRecords] = useState<Company[]>([]);
 
   useEffect(() => {
     const data = sortBy(companies, sortStatus.columnAccessor);
@@ -45,6 +46,8 @@ export default function ResizingComplexExample() {
       <DataTable
         withTableBorder={withTableBorder}
         withColumnBorders={withColumnBorders}
+        selectedRecords={selectedRecords}
+        onSelectedRecordsChange={setSelectedRecords}
         storeColumnsKey={key}
         records={records}
         columns={effectiveColumns}

--- a/package/DataTable.css
+++ b/package/DataTable.css
@@ -23,24 +23,17 @@
     light-dark(--mantine-datatable-highlight-on-hover-color-light, --mantine-datatable-highlight-on-hover-color-dark),
     light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5))
   );
-  --mantine-datatable-shadow-background-top: linear-gradient(rgba(0, 0, 0, light-dark(0.05, 0.25)), rgba(0, 0, 0, 0)),
+  --mantine-datatable-shadow-background-top:
+    linear-gradient(rgba(0, 0, 0, light-dark(0.05, 0.25)), rgba(0, 0, 0, 0)),
     linear-gradient(rgba(0, 0, 0, light-dark(0.05, 0.25)) 30%, rgba(0, 0, 0, 0));
-  --mantine-datatable-shadow-background-right: linear-gradient(
-      to left,
-      rgba(0, 0, 0, light-dark(0.05, 0.25)),
-      rgba(0, 0, 0, 0)
-    ),
+  --mantine-datatable-shadow-background-right:
+    linear-gradient(to left, rgba(0, 0, 0, light-dark(0.05, 0.25)), rgba(0, 0, 0, 0)),
     linear-gradient(to left, rgba(0, 0, 0, light-dark(0.05, 0.25)), rgba(0, 0, 0, 0) 30%);
-  --mantine-datatable-shadow-background-bottom: linear-gradient(
-      rgba(0, 0, 0, 0),
-      rgba(0, 0, 0, light-dark(0.05, 0.25))
-    ),
+  --mantine-datatable-shadow-background-bottom:
+    linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, light-dark(0.05, 0.25))),
     linear-gradient(rgba(0, 0, 0, 0) 30%, rgba(0, 0, 0, light-dark(0.05, 0.25)));
-  --mantine-datatable-shadow-background-left: linear-gradient(
-      to right,
-      rgba(0, 0, 0, light-dark(0.05, 0.25)),
-      rgba(0, 0, 0, 0)
-    ),
+  --mantine-datatable-shadow-background-left:
+    linear-gradient(to right, rgba(0, 0, 0, light-dark(0.05, 0.25)), rgba(0, 0, 0, 0)),
     linear-gradient(to right, rgba(0, 0, 0, light-dark(0.05, 0.25)), rgba(0, 0, 0, 0) 30%);
 
   position: relative;

--- a/package/DataTableHeaderSelectorCell.css
+++ b/package/DataTableHeaderSelectorCell.css
@@ -1,5 +1,6 @@
 .mantine-datatable-header-selector-cell {
   position: sticky;
+  z-index: 1;
   width: 0;
   left: 0;
   &::after {


### PR DESCRIPTION
I've added z-index: 1 to the selection column in the table header. The missing z-index was causing issues when combined with the table's column resize feature.

Mentions:

- "yarn format" formatted the DataTable.css file also
- I've added the row selection feature in the complex example on the resize feature

Before:
<img width="719" alt="Captură de ecran din 2025-03-27 la 18 39 45" src="https://github.com/user-attachments/assets/767030e5-7249-4670-98b1-16db71c7dd7e" />

After:
<img width="814" alt="Captură de ecran din 2025-03-27 la 19 10 43" src="https://github.com/user-attachments/assets/8daaaac0-8e85-4722-86aa-58fc9d8dfe5c" />

