### PR TITLE
Add multilevel column grouping support

### DIFF
--- a/app/examples/column-grouping/MultilevelColumnGroupingExample.tsx
+++ b/app/examples/column-grouping/MultilevelColumnGroupingExample.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { DataTable } from '__PACKAGE__';
+import { employees } from '~/data';
+
+export function MultilevelColumnGroupingExample() {
+  return (
+    <DataTable
+      withTableBorder
+      withColumnBorders
+      records={employees.slice(0, 10)}
+      groups={[
+        {
+          id: 'personal-info',
+          title: 'Personal Information',
+          groups: [
+            {
+              id: 'name-group',
+              title: 'Name',
+              columns: [
+                {
+                  accessor: 'firstName',
+                  title: 'First Name',
+                  width: 120,
+                },
+                {
+                  accessor: 'lastName',
+                  title: 'Last Name',
+                  width: 120,
+                },
+              ],
+            },
+            {
+              id: 'demographics',
+              title: 'Demographics',
+              columns: [
+                {
+                  accessor: 'sex',
+                  title: 'Gender',
+                  width: 80,
+                },
+                {
+                  accessor: 'birthDate',
+                  title: 'Birth Date',
+                  width: 120,
+                  render: ({ birthDate }) => new Date(birthDate).toLocaleDateString(),
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'contact-info',
+          title: 'Contact Information',
+          groups: [
+            {
+              id: 'email-group',
+              title: 'Email',
+              columns: [
+                {
+                  accessor: 'email',
+                  title: 'Email Address',
+                  width: 250,
+                  ellipsis: true,
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'work-info',
+          title: 'Work Information',
+          groups: [
+            {
+              id: 'identifiers',
+              title: 'IDs',
+              columns: [
+                {
+                  accessor: 'id',
+                  title: 'Employee ID',
+                  width: 100,
+                  ellipsis: true,
+                },
+                {
+                  accessor: 'department.id',
+                  title: 'Department ID',
+                  width: 100,
+                  ellipsis: true,
+                },
+              ],
+            },
+          ],
+        },
+      ]}
+    />
+  );
+}

--- a/app/examples/column-grouping/page.tsx
+++ b/app/examples/column-grouping/page.tsx
@@ -4,12 +4,14 @@ import { CodeBlock } from '~/components/CodeBlock';
 import { ExternalLink } from '~/components/ExternalLink';
 import { InternalLink } from '~/components/InternalLink';
 import { PageNavigation } from '~/components/PageNavigation';
+import { PageSubtitle } from '~/components/PageSubtitle';
 import { PageTitle } from '~/components/PageTitle';
 import { Txt } from '~/components/Txt';
 import { UnorderedList } from '~/components/UnorderedList';
 import { readCodeFile } from '~/lib/code';
 import { allPromiseProps, getRouteMetadata } from '~/lib/utils';
 import { ColumnGroupingExample } from './ColumnGroupingExample';
+import { MultilevelColumnGroupingExample } from './MultilevelColumnGroupingExample';
 
 const PATH: Route = '/examples/column-grouping';
 
@@ -18,6 +20,7 @@ export const metadata = getRouteMetadata(PATH);
 export default async function ColumnGroupingExamplePage() {
   const code = await allPromiseProps({
     'ColumnGroupingExample.tsx': readCodeFile<string>(`${PATH}/ColumnGroupingExample.tsx`),
+    'MultilevelColumnGroupingExample.tsx': readCodeFile<string>(`${PATH}/MultilevelColumnGroupingExample.tsx`),
     'companies.json': readCodeFile<string>('/../data/companies.json'),
   });
 
@@ -83,6 +86,10 @@ export default async function ColumnGroupingExamplePage() {
       <ColumnGroupingExample />
       <Txt>Here is the code used to generate the table above:</Txt>
       <CodeBlock tabs={{ code, keys: ['ColumnGroupingExample.tsx', 'companies.json'] }} />
+      <PageSubtitle value="Multilevel column grouping" />
+      <MultilevelColumnGroupingExample />
+      <Txt>Here is the code used to generate the table above:</Txt>
+      <CodeBlock tabs={{ code, keys: ['MultilevelColumnGroupingExample.tsx', 'companies.json'] }} />
       <Txt>Head over to the next example to discover more features.</Txt>
       <PageNavigation of={PATH} />
     </>

--- a/package/DataTable.tsx
+++ b/package/DataTable.tsx
@@ -20,7 +20,7 @@ import {
 } from './hooks';
 import type { DataTableProps } from './types';
 import { TEXT_SELECTION_DISABLED } from './utilityClasses';
-import { differenceBy, getRecordId, uniqBy } from './utils';
+import { differenceBy, flattenColumns, getRecordId, uniqBy } from './utils';
 
 export function DataTable<T>({
   withTableBorder,
@@ -131,7 +131,7 @@ export function DataTable<T>({
   ...otherProps
 }: DataTableProps<T>) {
   const effectiveColumns = useMemo(() => {
-    return groups?.flatMap((group) => group.columns) ?? columns!;
+    return groups ? flattenColumns(groups) : columns!;
   }, [columns, groups]);
 
   const hasResizableColumns = useMemo(() => {
@@ -300,6 +300,7 @@ export function DataTable<T>({
                     selectorCellShadowVisible={selectorCellShadowVisible}
                     selectionColumnClassName={selectionColumnClassName}
                     selectionColumnStyle={selectionColumnStyle}
+                    withColumnBorders={otherProps.withColumnBorders}
                   />
                 </DataTableColumnsProvider>
               )}

--- a/package/DataTableColumnGroupHeaderCell.css
+++ b/package/DataTableColumnGroupHeaderCell.css
@@ -1,0 +1,3 @@
+.mantine-datatable-column-group-header-cell--needs-border {
+  border-inline-end: 1px solid var(--mantine-datatable-row-border-color);
+}

--- a/package/DataTableColumnGroupHeaderCell.tsx
+++ b/package/DataTableColumnGroupHeaderCell.tsx
@@ -4,31 +4,65 @@ import { useMemo } from 'react';
 import { useMediaQueriesStringOrFunction } from './hooks';
 import type { DataTableColumnGroup } from './types';
 import { TEXT_ALIGN_CENTER, TEXT_ALIGN_LEFT, TEXT_ALIGN_RIGHT } from './utilityClasses';
-import { humanize } from './utils';
+import { calculateColSpan, flattenColumns, humanize, needsRightBorder } from './utils';
 
 type DataTableColumnGroupHeaderCellProps<T> = {
   group: DataTableColumnGroup<T>;
+  maxDepth: number;
+  currentDepth: number;
+  previousGroups: readonly DataTableColumnGroup<T>[];
+  isLastGroup: boolean;
+  withColumnBorders?: boolean;
+  totalTableColumns: number;
 };
 
 export function DataTableColumnGroupHeaderCell<T>({
-  group: { id, columns, title, textAlign, className, style },
+  group: { id, columns, groups, title, textAlign, className, style },
+  maxDepth,
+  currentDepth,
+  previousGroups,
+  isLastGroup,
+  withColumnBorders = false,
+  totalTableColumns,
 }: DataTableColumnGroupHeaderCellProps<T>) {
-  const queries = useMemo(() => columns.map(({ visibleMediaQuery }) => visibleMediaQuery), [columns]);
+  const allColumns = useMemo(() => {
+    if (columns && columns.length > 0) {
+      return columns;
+    }
+    if (groups && groups.length > 0) {
+      return flattenColumns([{ id, columns, groups }]);
+    }
+    return [];
+  }, [columns, groups]);
+
+  const queries = useMemo(() => allColumns.map(({ visibleMediaQuery }) => visibleMediaQuery), [allColumns]);
   const visibles = useMediaQueriesStringOrFunction(queries);
-  const colSpan = useMemo(
-    () => columns.filter(({ hidden }, i) => !hidden && visibles?.[i]).length,
-    [columns, visibles]
-  );
+
+  const colSpan = useMemo(() => {
+    return calculateColSpan({ id, columns, groups }, visibles);
+  }, [id, columns, groups, visibles]);
+
+  const columnsBeforeGroup = useMemo(() => {
+    return previousGroups.reduce((sum, g) => sum + calculateColSpan(g, visibles), 0);
+  }, [previousGroups, visibles]);
+
+  const hasSubGroups = groups && groups.length > 0;
+  const rowSpan = hasSubGroups ? 1 : maxDepth - currentDepth;
+
+  const hasMoreColumns = columnsBeforeGroup + colSpan < totalTableColumns;
+  const needsBorder = needsRightBorder(isLastGroup, hasMoreColumns, withColumnBorders);
 
   return colSpan > 0 ? (
     <TableTh
       colSpan={colSpan}
+      rowSpan={rowSpan > 1 ? rowSpan : undefined}
       className={clsx(
         'mantine-datatable-column-group-header-cell',
         {
           [TEXT_ALIGN_LEFT]: textAlign === 'left',
           [TEXT_ALIGN_CENTER]: textAlign === 'center',
           [TEXT_ALIGN_RIGHT]: textAlign === 'right',
+          'mantine-datatable-column-group-header-cell--needs-border': needsBorder,
         },
         className
       )}

--- a/package/styles.css
+++ b/package/styles.css
@@ -9,6 +9,7 @@
 @import './DataTableHeaderCell.css';
 @import './DataTableHeaderCellFilter.css';
 @import './DataTableHeaderSelectorCell.css';
+@import './DataTableColumnGroupHeaderCell.css';
 @import './DataTableLoader.css';
 @import './DataTablePageSizeSelector.css';
 @import './DataTablePagination.css';

--- a/package/types/DataTableColumnGroup.ts
+++ b/package/types/DataTableColumnGroup.ts
@@ -21,8 +21,15 @@ export type DataTableColumnGroup<T = Record<string, unknown>> = {
 
   /**
    * Columns which are part of the group.
+   * Optional when groups are provided for multilevel grouping.
    */
-  columns: DataTableColumn<T>[];
+  columns?: DataTableColumn<T>[];
+
+  /**
+   * Nested column groups for multilevel grouping.
+   * When provided, columns should be omitted.
+   */
+  groups?: DataTableColumnGroup<T>[];
 
   /**
    * Optional className to apply to the column group header.


### PR DESCRIPTION
# Add multilevel column grouping support

  ## Summary

  This PR introduces multilevel (nested) column grouping functionality to
  mantine-datatable, allowing to create more complex and hierarchical table      
  headers.

  ## Background

  Hi! I'm relatively new to React (coming from Vue background), but I absolutely love       
  Mantine and mantine-datatable. While working on a project, I found myself needing
  multilevel column grouping functionality and I try to implement it by myself.

  ## Changes

  - Extended `DataTableColumnGroup` type to support nested groups via optional `groups`     
  property
  - Added utility functions for handling multilevel groups
  - Updated `DataTableHeader` to render multiple header rows based on group depth
  - Modified `DataTableColumnGroupHeaderCell` to handle rowSpan for leaf groups
  - Added example demonstrating 3-level column grouping

  ## Example
<img width="1076" height="581" alt="image" src="https://github.com/user-attachments/assets/fea306a2-f043-42bf-bb07-77cb66b8b88e" />

  ```tsx
groups={[
        {
          id: 'personal-info',
          title: 'Personal Information',
          groups: [
            {
              id: 'name-group',
              title: 'Name',
              columns: [
                {
                  accessor: 'firstName',
                  title: 'First Name',
                  width: 120,
                },
                {
                  accessor: 'lastName',
                  title: 'Last Name',
                  width: 120,
                },
              ],
            },
            {
              id: 'demographics',
              title: 'Demographics',
              columns: [
                {
                  accessor: 'sex',
                  title: 'Gender',
                  width: 80,
                },
                {
                  accessor: 'birthDate',
                  title: 'Birth Date',
                  width: 120,
                  render: ({ birthDate }) => new Date(birthDate).toLocaleDateString(),
                },
              ],
            },
          ],
        },
        {
          id: 'contact-info',
          title: 'Contact Information',
          groups: [
            {
              id: 'email-group',
              title: 'Email',
              columns: [
                {
                  accessor: 'email',
                  title: 'Email Address',
                  width: 250,
                  ellipsis: true,
                },
              ],
            },
          ],
        },
        {
          id: 'work-info',
          title: 'Work Information',
          groups: [
            {
              id: 'identifiers',
              title: 'IDs',
              columns: [
                {
                  accessor: 'id',
                  title: 'Employee ID',
                  width: 100,
                  ellipsis: true,
                },
                {
                  accessor: 'department.id',
                  title: 'Department ID',
                  width: 100,
                  ellipsis: true,
                },
              ],
            },
          ],
        },
      ]}
```

  I would really appreciate your feedback on this implementation. As I mentioned, I'm       
  new to React, Mantine and Mantine-datatable, so please let me know if there are any improvements I should make or edge-cases to mention.