### PR TITLE
Add onDismiss handler to handle Escape button click

### DIFF
--- a/package/DataTableHeaderCellFilter.tsx
+++ b/package/DataTableHeaderCellFilter.tsx
@@ -23,8 +23,8 @@ export function DataTableHeaderCellFilter<T>({
   let ref: RefObject<HTMLDivElement | null> | undefined = useClickOutside(close);
   if (filterPopoverDisableClickOutside) ref = undefined;
 
-  return (
-    <Popover withArrow shadow="md" opened={isOpen} onClose={close} trapFocus {...filterPopoverProps}>
+  return ( // Keep the expanded props before the open/close, or they could be overridden by the client
+    <Popover withArrow shadow="md" trapFocus {...filterPopoverProps} opened={isOpen} onClose={close} onDismiss={close}>
       <PopoverTarget>
         <ActionIcon
           className="mantine-datatable-header-cell-filter-action-icon"


### PR DESCRIPTION
This pull request adds support for the onDismiss parameter on the Mantine Popover used within DataTableHeaderCellFilter in mantine-datatable.

Currently, the DataTableHeaderCellFilter component creates an internal Popover but does not pass the close handler to the  Popover component. As a result, consumers of mantine-datatable cannot react when the filter popover is dismissed from an escape event.

This PR forwards the close callback to the underlying Popover onDismiss handler, allowing the filter to respond to popover dismissal events.